### PR TITLE
Enforce Functions-only queue entry flow

### DIFF
--- a/app/amayadori/page.tsx
+++ b/app/amayadori/page.tsx
@@ -3,12 +3,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
-  addDoc,
-  collection,
   doc,
   onSnapshot,
-  serverTimestamp,
-  Timestamp,
 } from 'firebase/firestore';
 import { httpsCallable, getFunctions } from 'firebase/functions';
 import { auth, db, ensureAnon } from '@/lib/firebase';
@@ -34,6 +30,33 @@ type Msg = { id: string; text: string; isMe: boolean; nickname?: string; icon?: 
 type Drop = { i: number; x: number; delay: number; duration: number; width: number; height: number };
 
 const POST_LEAVE_AD_SEC = Number(process.env.NEXT_PUBLIC_POST_LEAVE_AD_SECONDS ?? 20);
+
+type QueueAction = 'join' | 'touch' | 'cancel';
+
+function getCallableCode(error: any): string {
+  return String(error?.code || '').replace(/^functions\//, '');
+}
+
+function getQueueErrorMessage(action: QueueAction, error: any): string {
+  const code = getCallableCode(error);
+  if (action === 'join') {
+    if (code === 'resource-exhausted') return '退室直後のため、少し待ってから再試行してください。';
+    if (code === 'failed-precondition') return 'いまは待機を開始できない状態です。条件をご確認のうえ、もう一度お試しください。';
+    if (code === 'unavailable') return '現在サーバー側で待機を開始できません。時間をおいて再試行してください。';
+    if (code === 'unauthenticated') return '認証の準備が整わなかったため、もう一度お試しください。';
+  }
+  if (action === 'touch') {
+    if (code === 'failed-precondition') return '待機状態が更新できなくなりました。もう一度入り直してください。';
+    if (code === 'permission-denied') return 'この待機状態は更新できませんでした。';
+    if (code === 'unavailable') return '待機状態の更新に失敗しました。時間をおいて再試行してください。';
+  }
+  if (action === 'cancel') {
+    if (code === 'failed-precondition') return 'この待機はすでに終了している可能性があります。画面を更新して状態をご確認ください。';
+    if (code === 'permission-denied') return 'この待機を終了できませんでした。';
+    if (code === 'unavailable') return '待機の終了処理に失敗しました。時間をおいて再試行してください。';
+  }
+  return '通信に失敗しました。時間をおいて再試行してください。';
+}
 
 // --- Functions の HTTP エンドポイント（sendBeacon 用）を自動生成 ---
 // auth.app.options.projectId を優先。なければ環境変数から。
@@ -89,6 +112,9 @@ export default function Page() {
 
   // 待機
   const [waitingMessage, setWaitingMessage] = useState('マッチング相手を探しています...');
+  const [waitingError, setWaitingError] = useState<string | null>(null);
+  const [lastJoinQueueKey, setLastJoinQueueKey] = useState<'country' | 'global' | null>(null);
+  const [isRetryingJoin, setIsRetryingJoin] = useState(false);
   const [ownerPrompt, setOwnerPrompt] = useState(false);
   const waitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -273,35 +299,38 @@ export default function Page() {
 
   // 待機のキャンセル（entryId が無くても必ずフォールバック実行）
   async function cancelCurrentEntry() {
-    if (isCancelling) return;           // 多重実行防止
+    if (isCancelling) return false;
     setIsCancelling(true);
     try {
       await ensureAnon();
       const fns = getFunctions(undefined, 'asia-northeast1');
       const id = entryIdRef.current;
 
-      // 1) 可能なら個別キャンセル
       if (id) {
-        try {
-          await httpsCallable(fns, 'cancelEntry')({ entryId: id });
-        } catch (e) {
-          console.warn('[cancelEntry] callable failed, fallback next', e);
-        }
+        await httpsCallable(fns, 'cancelEntry')({ entryId: id });
+      } else {
+        await httpsCallable(fns, 'cancelMyQueuedEntries')({});
       }
 
-      // 2) フォールバック：自分の queued を一括キャンセル
-      try {
-        await httpsCallable(fns, 'cancelMyQueuedEntries')({});
-      } catch (e) {
-        console.warn('[cancelMyQueuedEntries] callable failed', e);
-      }
-      // ※ 明示操作時は Callable で十分。Beacon は pagehide 専用に任せます。
-    } catch (e) {
-      console.error('[cancelCurrentEntry] failed', e);
-    } finally {
       entryIdRef.current = null;
       if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
       if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
+      setWaitingError(null);
+      return true;
+    } catch (e: any) {
+      const code = getCallableCode(e);
+      if (code !== 'failed-precondition') {
+        console.error('[cancelCurrentEntry] failed', e);
+        setWaitingError(getQueueErrorMessage('cancel', e));
+        return false;
+      }
+
+      entryIdRef.current = null;
+      if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
+      if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
+      setWaitingError(null);
+      return true;
+    } finally {
       setIsCancelling(false);
     }
   }
@@ -349,6 +378,8 @@ export default function Page() {
 
   // ▼ 待機キュー参加：プロフィール同梱 + ハートビート & キャンセル ▼
   async function handleJoin(queueKey: 'country' | 'global') {
+    setLastJoinQueueKey(queueKey);
+    setIsRetryingJoin(true);
     try {
       const left = remainingCooldownSec();
       if (left > 0) {
@@ -357,14 +388,15 @@ export default function Page() {
       }
 
       await ensureAnon();
-      await ensureIdTokenReady(); // ← 離脱検知用 Beacon に備え、先にトークンを確保
+      await ensureIdTokenReady();
       const uid = auth.currentUser?.uid;
       if (!uid) throw new Error('auth unavailable');
 
       setOwnerPrompt(false);
+      setWaitingError(null);
+      setWaitingMessage('マッチング相手を探しています...');
       setScreen('waiting');
 
-      // 監視/タイマー停止
       if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
       if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
       entryIdRef.current = null;
@@ -376,53 +408,31 @@ export default function Page() {
         icon: userIcon || localStorage.getItem('amayadori_icon') || DEFAULT_USER_ICON,
       };
 
-      let entryId: string | undefined;
-      try {
-        const res = (await fn({ queueKey, profile })) as any;
-        const status = res?.data?.status as string | undefined;
-        if (status === 'denied') {
-          setWaitingMessage('今日は条件外でした');
-          setTimeout(() => setScreen('region'), 2000);
-          return;
-        }
-        if (status === 'cooldown') {
-          const leftServer = Number(res?.data?.retryAfterSec ?? 30);
-          try { localStorage.setItem('amayadori_cd_until', String(Date.now() + leftServer * 1000)); } catch {}
-          startPostLeaveAd(leftServer, queueKey);
-          return;
-        }
-        entryId = res?.data?.entryId as string | undefined;
-      } catch (err) {
-        console.warn('[enter] callable error, fallback to client entry', err);
-      }
-
+      const res = (await fn({ queueKey, profile })) as any;
+      const entryId = res?.data?.entryId as string | undefined;
       if (!entryId) {
-        const expiresAt = Timestamp.fromDate(new Date(Date.now() + 1000 * 60 * 2));
-        const ref = await addDoc(collection(db, 'matchEntries'), {
-          uid,
-          queueKey,
-          status: 'queued',
-          createdAt: serverTimestamp(),
-          lastSeenAt: serverTimestamp(),
-          expiresAt,
-          source: 'client-fallback',
-          profile,
-        });
-        entryId = ref.id;
+        throw new Error('enter returned without entryId');
       }
 
-      // entryId を保持
       entryIdRef.current = entryId;
 
-      // ハートビート（10秒おきに lastSeenAt 更新）
       const touch = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'touchEntry');
       heartbeatTimerRef.current = setInterval(() => {
         const id = entryIdRef.current;
         if (!id) return;
-        touch({ entryId: id }).catch(() => {});
+        touch({ entryId: id }).catch((err) => {
+          const code = getCallableCode(err);
+          console.warn('[touchEntry] callable failed', err);
+          if (code === 'failed-precondition' || code === 'permission-denied' || code === 'unavailable') {
+            if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
+            entryIdRef.current = null;
+            setWaitingMessage('待機が中断されました。');
+            setWaitingError(getQueueErrorMessage('touch', err));
+            setOwnerPrompt(false);
+          }
+        });
       }, 10_000);
 
-      // 自分の1件だけを監視 → matched で /chat へ
       entryUnsubRef.current = onSnapshot(doc(db, 'matchEntries', entryId), (snap) => {
         // ★ オーナー遷移中は待機UIを更新しない（「中断されました」等を出さない）
         if (ownerSwitchingRef.current) return;
@@ -443,18 +453,31 @@ export default function Page() {
           setTimeout(() => setScreen('region'), 2000);
         }
         if (d.status === 'stale' || d.status === 'canceled' || d.status === 'expired') {
-          setWaitingMessage('待機が中断されました。もう一度お試しください。');
-          setTimeout(() => setScreen('region'), 1500);
+          setWaitingMessage('待機が中断されました。');
+          setWaitingError('待機状態が終了したため、再度参加してください。');
+          setOwnerPrompt(false);
+          if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
+          entryIdRef.current = null;
         }
       });
 
-      // 20秒でオーナー提案
       if (waitingTimerRef.current) clearTimeout(waitingTimerRef.current);
       waitingTimerRef.current = setTimeout(() => setOwnerPrompt(true), 20000);
     } catch (e: any) {
-      console.error(e);
-      alert(e?.message || '入室に失敗しました');
-      setScreen('region');
+      console.error('[enter] failed', e);
+      const code = getCallableCode(e);
+      const retryAfterSec = Number(e?.details?.retryAfterSec ?? 0);
+      setWaitingMessage('待機を開始できませんでした。');
+      setWaitingError(getQueueErrorMessage('join', e));
+      setOwnerPrompt(false);
+      if (code === 'resource-exhausted' && retryAfterSec > 0) {
+        try { localStorage.setItem('amayadori_cd_until', String(Date.now() + retryAfterSec * 1000)); } catch {}
+        startPostLeaveAd(retryAfterSec, queueKey);
+        return;
+      }
+      setScreen('waiting');
+    } finally {
+      setIsRetryingJoin(false);
     }
   }
 
@@ -514,8 +537,8 @@ export default function Page() {
 
   // 待機をやめる（ボタン）
   async function abortWaiting() {
-    await cancelCurrentEntry();
-    setScreen('region');
+    const ok = await cancelCurrentEntry();
+    if (ok) setScreen('region');
   }
 
   // ダミー広告（リワード）
@@ -699,6 +722,28 @@ export default function Page() {
               </div>
               <h2 id="waiting-message" className="text-2xl font-bold">{waitingMessage}</h2>
               <p className="text-sm text-gray-400">雨の中、誰かが来るのを待っています。</p>
+
+              {waitingError && (
+                <div className="rounded-xl border border-red-400/40 bg-red-500/10 p-4 text-left text-sm text-red-100 space-y-3">
+                  <p>{waitingError}</p>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <button
+                      className="rounded-lg bg-white/10 px-4 py-2 font-semibold text-white disabled:opacity-50"
+                      onClick={() => lastJoinQueueKey && handleJoin(lastJoinQueueKey)}
+                      disabled={!lastJoinQueueKey || isRetryingJoin || isCancelling}
+                    >
+                      {isRetryingJoin ? '再試行中...' : 'もう一度試す'}
+                    </button>
+                    <button
+                      className="rounded-lg border border-white/20 px-4 py-2 text-white/90"
+                      onClick={() => setScreen('region')}
+                      disabled={isCancelling}
+                    >
+                      エントランスへ戻る
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {/* 待機をやめる */}
               <button

--- a/firebase.json
+++ b/firebase.json
@@ -19,35 +19,59 @@
   ],
   "hosting": {
     "public": "out",
-    "ignore": ["**/.*", "**/node_modules/**"],
+    "ignore": [
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "cleanUrls": true,
     "headers": [
       {
         "source": "/_next/**",
         "headers": [
-          { "key": "Cache-Control", "value": "public,max-age=31536000,immutable" }
+          {
+            "key": "Cache-Control",
+            "value": "public,max-age=31536000,immutable"
+          }
         ]
       },
       {
         "source": "**/*.@(js|css|png|jpg|jpeg|gif|webp|svg|ico|woff|woff2|ttf)",
         "headers": [
-          { "key": "Cache-Control", "value": "public,max-age=31536000,immutable" }
+          {
+            "key": "Cache-Control",
+            "value": "public,max-age=31536000,immutable"
+          }
         ]
       },
       {
         "source": "**",
         "headers": [
-          { "key": "X-Content-Type-Options", "value": "nosniff" },
-          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          }
         ]
       }
     ],
     "rewrites": [
       {
         "source": "/api/cancelQueuedEntries",
-        "function": { "functionId": "cancelQueuedEntriesHttp", "region": "asia-northeast1" }
+        "function": {
+          "functionId": "cancelQueuedEntriesHttp",
+          "region": "asia-northeast1"
+        }
       },
-      { "source": "**", "destination": "/index.html" }
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    match /matchEntries/{entryId} {
+      allow get, list: if isSignedIn() && resource.data.uid == request.auth.uid;
+      allow create, update, delete: if false;
+    }
+
+    match /{document=**} {
+      allow read, write: if isSignedIn();
+    }
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,7 @@
 // functions/src/index.ts
 import * as admin from 'firebase-admin'
 import { onCall, HttpsError, onRequest } from 'firebase-functions/v2/https'
+import * as logger from 'firebase-functions/logger'
 import { onDocumentCreated, onDocumentUpdated } from 'firebase-functions/v2/firestore'
 import { onSchedule } from 'firebase-functions/v2/scheduler'
 import type { Request, Response } from 'express'
@@ -198,12 +199,42 @@ async function getWeather(_lat?: number, _lon?: number) {
 function isAllowedByPolicy(_w: any) {
   return true
 }
+function sanitizeErrorForLog(error: unknown) {
+  if (error instanceof HttpsError) {
+    return { code: error.code, message: error.message }
+  }
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message }
+  }
+  return { message: String(error) }
+}
+
+async function recordEnterDiagnostic(params: {
+  uid: string
+  queueKey?: string
+  stage: string
+  reason: string
+  code: string
+  region?: string
+  detail?: Record<string, unknown>
+}) {
+  const payload = {
+    uid: params.uid,
+    queueKey: params.queueKey ?? null,
+    stage: params.stage,
+    reason: params.reason,
+    code: params.code,
+    region: params.region ?? null,
+    detail: params.detail ?? {},
+    at: admin.firestore.FieldValue.serverTimestamp(),
+  }
+  logger.error('enter_failure', payload)
+  await db.collection('_diag_enter').add(payload)
+}
 
 /* ============ enter ============ */
 type EnterQueued = { status: 'queued'; entryId: string }
-type EnterDenied = { status: 'denied' }
-type EnterCooldown = { status: 'cooldown'; retryAfterSec: number }
-type EnterRes = EnterQueued | EnterDenied | EnterCooldown
+type EnterRes = EnterQueued
 
 export const enter = onCall(
   { region: 'asia-northeast1' },
@@ -220,11 +251,39 @@ export const enter = onCall(
     }
     if (!queueKey) throw new HttpsError('invalid-argument', 'queueKey required')
 
+    const failEnter = async (args: {
+      code: 'unavailable' | 'failed-precondition' | 'resource-exhausted'
+      reason: string
+      stage: string
+      message: string
+      detail?: Record<string, unknown>
+    }): Promise<never> => {
+      try {
+        await recordEnterDiagnostic({
+          uid,
+          queueKey,
+          stage: args.stage,
+          reason: args.reason,
+          code: args.code,
+          region,
+          detail: args.detail,
+        })
+      } catch (diagError) {
+        logger.error('enter_diag_failed', {
+          uid,
+          queueKey,
+          stage: args.stage,
+          reason: args.reason,
+          diagError: sanitizeErrorForLog(diagError),
+        })
+      }
+      throw new HttpsError(args.code, args.message)
+    }
+
     const cfg = await getConfig()
     const weatherMode = cfg.weatherGateMode ?? 'off'
     const cooldownSec = cfg.cooldownSec ?? DEFAULT_COOLDOWN_SEC
 
-    // クールダウン
     try {
       const st = await db.doc(`userStates/${uid}`).get()
       const lastLeftAt = st.exists ? (st.data() as any).lastLeftAt : null
@@ -234,12 +293,25 @@ export const enter = onCall(
         if (remain > 0) {
           await incDaily({ queue_cooldown_total: 1 })
           await logEvent({ type: 'queue_cooldown', uid, queueKey })
-          return { status: 'cooldown', retryAfterSec: remain }
+          await failEnter({
+            code: 'resource-exhausted',
+            reason: 'cooldown_active',
+            stage: 'cooldown',
+            message: '退室直後のため少し待ってから再度お試しください。',
+            detail: { retryAfterSec: remain },
+          })
         }
       }
-    } catch {}
+    } catch (error) {
+      await failEnter({
+        code: 'unavailable',
+        reason: 'cooldown_check_failed',
+        stage: 'cooldown',
+        message: '待機状態を確認できませんでした。時間をおいて再度お試しください。',
+        detail: sanitizeErrorForLog(error),
+      })
+    }
 
-    // 天候（log-only / enforce）
     if (weatherMode !== 'off') {
       let ok = true
       try {
@@ -254,7 +326,7 @@ export const enter = onCall(
           ok,
           at: admin.firestore.FieldValue.serverTimestamp(),
         })
-      } catch (e) {
+      } catch (error) {
         await db.collection('_diag_weather').add({
           uid,
           lat,
@@ -262,37 +334,51 @@ export const enter = onCall(
           region,
           mode: weatherMode,
           ok: true,
-          error: String(e),
+          error: String(error),
           at: admin.firestore.FieldValue.serverTimestamp(),
         })
       }
       if (weatherMode === 'enforce' && !ok) {
         await incDaily({ queue_denied_total: 1 })
         await logEvent({ type: 'queue_denied', uid, queueKey })
-        return { status: 'denied' }
+        await failEnter({
+          code: 'failed-precondition',
+          reason: 'weather_gate_denied',
+          stage: 'policy',
+          message: '現在の条件では待機を開始できません。',
+          detail: { weatherMode },
+        })
       }
     }
 
-    // matchEntries を作成（プロフィール & lastSeenAt 付き）
-    const entryRef = db.collection('matchEntries').doc()
-    await entryRef.set({
-      uid,
-      queueKey,
-      status: 'queued',
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      lastSeenAt: admin.firestore.FieldValue.serverTimestamp(), // 初期ハートビート
-      expiresAt: tsPlusMin(QUEUE_EXPIRE_MIN),
-      profile: sanitizeProfile(profile),
-    })
+    try {
+      const entryRef = db.collection('matchEntries').doc()
+      await entryRef.set({
+        uid,
+        queueKey,
+        status: 'queued',
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastSeenAt: admin.firestore.FieldValue.serverTimestamp(),
+        expiresAt: tsPlusMin(QUEUE_EXPIRE_MIN),
+        profile: sanitizeProfile(profile),
+      })
 
-    // KPI: キュー投入
-    const inc: Record<string, number> = { queue_enter_total: 1 }
-    if (queueKey === 'country') inc['queue_enter_country_total'] = 1
-    if (queueKey === 'global') inc['queue_enter_global_total'] = 1
-    await incDaily(inc)
-    await logEvent({ type: 'queue_enter', uid, queueKey })
+      const inc: Record<string, number> = { queue_enter_total: 1 }
+      if (queueKey === 'country') inc['queue_enter_country_total'] = 1
+      if (queueKey === 'global') inc['queue_enter_global_total'] = 1
+      await incDaily(inc)
+      await logEvent({ type: 'queue_enter', uid, queueKey })
 
-    return { status: 'queued', entryId: entryRef.id }
+      return { status: 'queued', entryId: entryRef.id }
+    } catch (error) {
+      return await failEnter({
+        code: 'unavailable',
+        reason: 'entry_create_failed',
+        stage: 'write_entry',
+        message: '待機エントリーの作成に失敗しました。時間をおいて再度お試しください。',
+        detail: sanitizeErrorForLog(error),
+      })
+    }
   }
 )
 
@@ -305,19 +391,20 @@ export const touchEntry = onCall({ region: 'asia-northeast1' }, async (req) => {
   if (!entryId) throw new HttpsError('invalid-argument', 'entryId required')
 
   const ref = db.collection('matchEntries').doc(entryId)
-  await db.runTransaction(async (tx) => {
+  return db.runTransaction(async (tx) => {
     const s = await tx.get(ref)
-    if (!s.exists) return
+    if (!s.exists) throw new HttpsError('failed-precondition', 'entry_missing')
     const d = s.data() as any
     if (d.uid !== uid) throw new HttpsError('permission-denied', 'not owner')
-    if (d.status !== 'queued') return
+    if (d.status !== 'queued') {
+      throw new HttpsError('failed-precondition', 'entry_not_queued')
+    }
     tx.update(ref, {
       lastSeenAt: nowTs(),
-      // 生かしている間は期限も伸ばす
       expiresAt: tsPlusMin(QUEUE_EXPIRE_MIN),
     })
+    return { ok: true }
   })
-  return { ok: true }
 })
 
 // 待機をやめる（所有者のみ）
@@ -330,19 +417,21 @@ export const cancelEntry = onCall(
     if (!entryId) throw new HttpsError('invalid-argument', 'entryId required')
 
     const ref = db.collection('matchEntries').doc(entryId)
-    await db.runTransaction(async (tx) => {
+    return db.runTransaction(async (tx) => {
       const s = await tx.get(ref)
-      if (!s.exists) return
+      if (!s.exists) throw new HttpsError('failed-precondition', 'entry_missing')
       const d = s.data() as any
       if (d.uid !== uid) throw new HttpsError('permission-denied', 'not owner')
-      if (d.status !== 'queued') return
+      if (d.status !== 'queued') {
+        throw new HttpsError('failed-precondition', 'entry_not_queued')
+      }
       tx.update(ref, {
         status: 'canceled',
         canceledAt: nowTs(),
-        expiresAt: nowTs(), // GC 対象
+        expiresAt: nowTs(),
       })
+      return { ok: true }
     })
-    return { ok: true }
   }
 )
 
@@ -360,7 +449,7 @@ export const cancelMyQueuedEntries = onCall(
       .limit(50)
       .get()
 
-    if (qs.empty) return { canceled: 0 }
+    if (qs.empty) throw new HttpsError('failed-precondition', 'no_queued_entries')
 
     const batch = db.batch()
     qs.docs.forEach((d) => {


### PR DESCRIPTION
### Motivation

- Ensure `matchEntries` is created and mutated only by server-side logic so client-side races and inconsistent state are avoided. 
- Make `enter` / queue-related callables return consistent, screen-friendly error codes (`unavailable`, `failed-precondition`, `resource-exhausted`) so the UI can offer clear retry/UX paths. 
- Add structured diagnostics for `enter` failures to simplify incident investigation and reduce client-side fallback writes.

### Description

- Remove the client-side fallback that directly wrote to `matchEntries` in `app/amayadori/page.tsx` so `handleJoin` now only proceeds when the `enter` callable returns an `entryId`. 
- Add client-side helpers `getCallableCode` and `getQueueErrorMessage` and surface a `waitingError` UI with a retry action and user-friendly messages; make `cancelCurrentEntry`, `abortWaiting` and heartbeat handling interpret function error codes instead of falling back to direct writes. 
- Normalize server-side `enter` behavior in `functions/src/index.ts` to record diagnostic entries (`_diag_enter`) and structured logs (`logger.error`) and to fail with clear `HttpsError` codes (`resource-exhausted`, `failed-precondition`, `unavailable`) for cooldown/policy/write/config failures; update `touchEntry`, `cancelEntry`, and `cancelMyQueuedEntries` to return `failed-precondition` / `permission-denied` where appropriate. 
- Add Firestore rules (`firestore.rules`) and update `firebase.json` so client direct `create`/`update`/`delete` on `matchEntries` is denied and reads are limited to the entry owner.

### Testing

- Ran `npm --prefix functions run build` to compile Cloud Functions TypeScript, which completed successfully. 
- Ran `npx eslint app/amayadori/page.tsx`, which finished with warnings only (hooks and image warnings). 
- Ran `npm run build` for the Next app; this environment failed during Next.js build due to inability to fetch Google Fonts (`Inter` / `Noto Serif JP`), so a full production build could not be completed here (failure is environmental, not related to the queue changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae86d2cbc8333b8286f075016aa1e)