### PR TITLE
待機・入退室フローを状態遷移ベースにリファクタリング

### DIFF
--- a/app/amayadori/page.tsx
+++ b/app/amayadori/page.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  doc,
-  onSnapshot,
-} from 'firebase/firestore';
-import { httpsCallable, getFunctions } from 'firebase/functions';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { getFunctions, httpsCallable } from 'firebase/functions';
 import { auth, db, ensureAnon } from '@/lib/firebase';
 
-const DEFAULT_USER_ICON =
-  'https://storage.googleapis.com/amayadori/defaultIcon.png';
-const OWNER_ICON =
-  'https://storage.googleapis.com/amayadori/cafeownerIcon.png';
+const DEFAULT_USER_ICON = 'https://storage.googleapis.com/amayadori/defaultIcon.png';
+const OWNER_ICON = 'https://storage.googleapis.com/amayadori/cafeownerIcon.png';
+const POST_LEAVE_AD_SEC = Number(process.env.NEXT_PUBLIC_POST_LEAVE_AD_SECONDS ?? 20);
 
 const conversationStarters = [
   'おすすめのコーヒーは？',
@@ -25,13 +21,70 @@ const conversationStarters = [
   '何か面白い話、ありますか？',
 ];
 
-type Screen = 'profile' | 'region' | 'waiting' | 'chat';
+type FlowState = 'profile' | 'region' | 'joining' | 'waiting' | 'matched' | 'chat' | 'leaving' | 'cooldown';
+type QueueKey = 'country' | 'global';
+type QueueAction = 'join' | 'touch' | 'cancel';
+type MatchEntryStatus = 'matched' | 'denied' | 'stale' | 'canceled' | 'expired' | 'waiting';
 type Msg = { id: string; text: string; isMe: boolean; nickname?: string; icon?: string };
 type Drop = { i: number; x: number; delay: number; duration: number; width: number; height: number };
 
-const POST_LEAVE_AD_SEC = Number(process.env.NEXT_PUBLIC_POST_LEAVE_AD_SECONDS ?? 20);
+type UiState = {
+  waitingMessage: string;
+  waitingError: string | null;
+  ownerPrompt: boolean;
+  showPostLeaveAd: boolean;
+  postLeaveLeft: number;
+  showInterstitial: boolean;
+  showRewarded: boolean;
+  rewardLeft: number;
+  customAlert: string | null;
+};
 
-type QueueAction = 'join' | 'touch' | 'cancel';
+type SyncState = {
+  activeQueueKey: QueueKey | null;
+  pendingQueueKey: QueueKey | null;
+  lastJoinQueueKey: QueueKey | null;
+  isRetryingJoin: boolean;
+  isCancelling: boolean;
+  ownerRoomTransition: boolean;
+  activeEntryId: string | null;
+  joinAttemptKey: string | null;
+};
+
+const initialUiState: UiState = {
+  waitingMessage: 'マッチング相手を探しています...',
+  waitingError: null,
+  ownerPrompt: false,
+  showPostLeaveAd: false,
+  postLeaveLeft: POST_LEAVE_AD_SEC,
+  showInterstitial: false,
+  showRewarded: false,
+  rewardLeft: 5,
+  customAlert: null,
+};
+
+const initialSyncState: SyncState = {
+  activeQueueKey: null,
+  pendingQueueKey: null,
+  lastJoinQueueKey: null,
+  isRetryingJoin: false,
+  isCancelling: false,
+  ownerRoomTransition: false,
+  activeEntryId: null,
+  joinAttemptKey: null,
+};
+
+const EVENT_CLEANUP_MATRIX = {
+  pagehide: ['ownerPrompt timer stop', 'heartbeat stop', 'snapshot unsubscribe skipped', 'beacon cancel only'],
+  matched: ['ownerPrompt timer stop', 'heartbeat stop', 'snapshot unsubscribe', 'stale UI guard on'],
+  cancel: ['ownerPrompt timer stop', 'heartbeat stop', 'snapshot unsubscribe', 'pending queue clear'],
+  cooldown: ['ownerPrompt timer stop', 'heartbeat stop', 'snapshot unsubscribe', 'cooldown timer start'],
+  owner: ['ownerPrompt timer stop', 'heartbeat stop', 'snapshot unsubscribe', 'waiting error guard on'],
+} as const;
+
+function logFlow(label: string, payload?: Record<string, unknown>) {
+  console.info(`[amayadori:${label}]`, payload ?? {});
+}
 
 function getCallableCode(error: any): string {
   return String(error?.code || '').replace(/^functions\//, '');
@@ -58,8 +111,6 @@ function getQueueErrorMessage(action: QueueAction, error: any): string {
   return '通信に失敗しました。時間をおいて再試行してください。';
 }
 
-// --- Functions の HTTP エンドポイント（sendBeacon 用）を自動生成 ---
-// auth.app.options.projectId を優先。なければ環境変数から。
 function resolveCancelBeaconUrl(): string {
   // @ts-ignore
   const pid = auth?.app?.options?.projectId || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
@@ -68,104 +119,109 @@ function resolveCancelBeaconUrl(): string {
 
 export default function Page() {
   const router = useRouter();
-
-  // 画面・状態
-  const [screen, setScreen] = useState<Screen>('profile');
+  const [flow, setFlow] = useState<FlowState>('profile');
   const [doorOpen, setDoorOpen] = useState(false);
-
-  // プロフィール（初期復元：トップで入力した内容を常に表示）
   const [userNickname, setUserNickname] = useState('あなた');
-  const [userIcon, setUserIcon] = useState<string>('');
+  const [userIcon, setUserIcon] = useState('');
   const [userProfile, setUserProfile] = useState('...');
-
-  useEffect(() => {
-    try {
-      const nn = localStorage.getItem('amayadori_nickname');
-      const pf = localStorage.getItem('amayadori_profile');
-      const ic = localStorage.getItem('amayadori_icon');
-      if (nn) setUserNickname(nn);
-      if (pf) setUserProfile(pf);
-      if (ic) setUserIcon(ic);
-    } catch {}
-  }, []);
-
-  // ====== 追加: AmayadoriページPV送信（1回だけ） ======
-  const sentAmayadoriPV = useRef(false);
-  useEffect(() => {
-    if (sentAmayadoriPV.current) return;
-    sentAmayadoriPV.current = true;
-    (async () => {
-      try {
-        await ensureAnon();
-        const fns = getFunctions(undefined, 'asia-northeast1');
-        const call = httpsCallable(fns, 'trackVisit');
-        await call({
-          page: 'amayadori',
-          src: typeof document !== 'undefined' ? document.referrer : '',
-        });
-      } catch {
-        /* noop */
-      }
-    })();
-  }, []);
-  // ==============================================
-
-  // 待機
-  const [waitingMessage, setWaitingMessage] = useState('マッチング相手を探しています...');
-  const [waitingError, setWaitingError] = useState<string | null>(null);
-  const [lastJoinQueueKey, setLastJoinQueueKey] = useState<'country' | 'global' | null>(null);
-  const [isRetryingJoin, setIsRetryingJoin] = useState(false);
-  const [ownerPrompt, setOwnerPrompt] = useState(false);
-  const waitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // エントリー監視/管理（ハートビート＆キャンセル）
-  const entryUnsubRef = useRef<(() => void) | null>(null);
-  const entryIdRef = useRef<string | null>(null);
-  const heartbeatTimerRef = useRef<any>(null);
-  const [isCancelling, setIsCancelling] = useState(false);
-
-  // ★ オーナー遷移中フラグ：待機UI更新を抑止
-  const ownerSwitchingRef = useRef(false);
-
-  // チャット（モック）
+  const [ui, setUi] = useState<UiState>(initialUiState);
+  const [syncState, setSyncState] = useState<SyncState>(initialSyncState);
   const [roomName, setRoomName] = useState('Cafe Amayadori');
   const [userCount, setUserCount] = useState('オーナーとあなた');
   const [msgs, setMsgs] = useState<Msg[]>([]);
   const [draft, setDraft] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
-
-  // 既存のダミー広告
-  const [showInterstitial, setShowInterstitial] = useState(false);
-  const [showRewarded, setShowRewarded] = useState(false);
-  const [rewardLeft, setRewardLeft] = useState(5);
-  const [customAlert, setCustomAlert] = useState<string | null>(null);
-
-  // 退室後広告（別タブ対策）
-  const [showPostLeaveAd, setShowPostLeaveAd] = useState(false);
-  const [postLeaveLeft, setPostLeaveLeft] = useState(POST_LEAVE_AD_SEC);
-  const [pendingQueueKey, setPendingQueueKey] = useState<null | 'country' | 'global'>(null);
-  const cdTimerRef = useRef<any>(null);
-
-  // 「今、待機中か？」の参照（ページ離脱検知で使用）
-  const isWaitingRef = useRef(false);
-  useEffect(() => { isWaitingRef.current = (screen === 'waiting'); }, [screen]);
-
-  // 💧 雨（ドロップ）— SSR/CSR差分を避けるため、マウント後に生成
   const [drops, setDrops] = useState<Drop[]>([]);
-  useEffect(() => {
-    const arr: Drop[] = Array.from({ length: 100 }).map((_, i) => {
-      const x = Math.random() * 100;
-      const delay = Math.random() * 2;
-      const duration = 0.5 + Math.random() * 0.5;
-      const width = 1 + Math.random() * 2;
-      const height = 60 + Math.random() * 40;
-      return { i, x, delay, duration, width, height };
-    });
-    setDrops(arr);
-  }, []);
 
-  // 入力欄のオートリサイズ
+  const waitingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cooldownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const rewardedTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const entryUnsubRef = useRef<(() => void) | null>(null);
+  const idTokenRef = useRef<string | null>(null);
+  const beaconUrlRef = useRef<string>(resolveCancelBeaconUrl());
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const sentAmayadoriPV = useRef(false);
+  const activeJoinAttemptRef = useRef<string | null>(null);
+  const flowRef = useRef<FlowState>('profile');
+  const syncRef = useRef(syncState);
+
+  useEffect(() => { flowRef.current = flow; }, [flow]);
+  useEffect(() => { syncRef.current = syncState; }, [syncState]);
+
+  const isWaitingFlow = useMemo(() => flow === 'joining' || flow === 'waiting', [flow]);
+
+  function setUiPatch(patch: Partial<UiState>) {
+    setUi((prev) => ({ ...prev, ...patch }));
+  }
+
+  function setSyncPatch(patch: Partial<SyncState>) {
+    setSyncState((prev) => ({ ...prev, ...patch }));
+  }
+
+  function stopOwnerPromptTimer(reason: string) {
+    if (waitingTimerRef.current) {
+      clearTimeout(waitingTimerRef.current);
+      waitingTimerRef.current = null;
+      logFlow('timer:ownerPrompt:stop', { reason });
+    }
+  }
+
+  function stopHeartbeat(reason: string) {
+    if (heartbeatTimerRef.current) {
+      clearInterval(heartbeatTimerRef.current);
+      heartbeatTimerRef.current = null;
+      logFlow('timer:heartbeat:stop', { reason });
+    }
+  }
+
+  function stopCooldownTimer(reason: string) {
+    if (cooldownTimerRef.current) {
+      clearInterval(cooldownTimerRef.current);
+      cooldownTimerRef.current = null;
+      logFlow('timer:cooldown:stop', { reason });
+    }
+  }
+
+  function stopRewardedTimer(reason: string) {
+    if (rewardedTimerRef.current) {
+      clearInterval(rewardedTimerRef.current);
+      rewardedTimerRef.current = null;
+      logFlow('timer:rewarded:stop', { reason });
+    }
+  }
+
+  function detachEntryListener(reason: string) {
+    if (entryUnsubRef.current) {
+      entryUnsubRef.current();
+      entryUnsubRef.current = null;
+      logFlow('listener:entry:detach', { reason });
+    }
+  }
+
+  function clearQueueRuntime(reason: string) {
+    stopOwnerPromptTimer(reason);
+    stopHeartbeat(reason);
+    detachEntryListener(reason);
+    activeJoinAttemptRef.current = null;
+    setSyncPatch({ activeEntryId: null, activeQueueKey: null, joinAttemptKey: null });
+  }
+
+  function remainingCooldownSec(): number {
+    try {
+      const until = Number(localStorage.getItem('amayadori_cd_until') || '0');
+      const left = Math.ceil((until - Date.now()) / 1000);
+      return left > 0 ? left : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  function playDoor() {
+    setDoorOpen(true);
+    setTimeout(() => setDoorOpen(false), 1300);
+  }
+
   function autoResize() {
     const el = taRef.current;
     if (!el) return;
@@ -179,13 +235,313 @@ export default function Page() {
     }
   }
 
-  // 扉アニメーション
-  function playDoor() {
-    setDoorOpen(true);
-    setTimeout(() => setDoorOpen(false), 1300);
+  function buildProfile() {
+    return {
+      nickname: userNickname || localStorage.getItem('amayadori_nickname') || 'あなた',
+      profile: userProfile || localStorage.getItem('amayadori_profile') || '...',
+      icon: userIcon || localStorage.getItem('amayadori_icon') || DEFAULT_USER_ICON,
+    };
   }
 
-  // 画像プレビュー
+  async function ensureIdTokenReady() {
+    await ensureAnon();
+    try {
+      idTokenRef.current = await auth.currentUser!.getIdToken(false);
+    } catch {
+      idTokenRef.current = null;
+    }
+  }
+
+  function sendBeaconCancel(): boolean {
+    try {
+      const token = idTokenRef.current;
+      const url = beaconUrlRef.current;
+      if (!token || !url) return false;
+      if ('sendBeacon' in navigator) {
+        const body = new Blob([`idToken=${encodeURIComponent(token)}`], {
+          type: 'application/x-www-form-urlencoded; charset=UTF-8',
+        });
+        const ok = navigator.sendBeacon(url, body);
+        logFlow('pagehide:beacon', { ok, cleanup: EVENT_CLEANUP_MATRIX.pagehide });
+        return ok;
+      }
+    } catch {
+      // noop
+    }
+    return false;
+  }
+
+  async function cancelCurrentEntry(reason: string) {
+    const current = syncRef.current;
+    if (current.isCancelling) {
+      logFlow('cancel:skip-duplicate', { reason, entryId: current.activeEntryId });
+      return false;
+    }
+
+    setSyncPatch({ isCancelling: true });
+    stopOwnerPromptTimer(`cancel:${reason}`);
+
+    try {
+      await ensureAnon();
+      const fns = getFunctions(undefined, 'asia-northeast1');
+      const id = syncRef.current.activeEntryId;
+      if (id) {
+        await httpsCallable(fns, 'cancelEntry')({ entryId: id });
+      } else {
+        await httpsCallable(fns, 'cancelMyQueuedEntries')({});
+      }
+      clearQueueRuntime(`cancel:${reason}`);
+      setUiPatch({ waitingError: null, ownerPrompt: false });
+      logFlow('cancel:done', { reason, cleanup: EVENT_CLEANUP_MATRIX.cancel });
+      return true;
+    } catch (e: any) {
+      const code = getCallableCode(e);
+      if (code === 'failed-precondition') {
+        clearQueueRuntime(`cancel:failed-precondition:${reason}`);
+        setUiPatch({ waitingError: null, ownerPrompt: false });
+        return true;
+      }
+      console.error('[cancelCurrentEntry] failed', e);
+      if (!syncRef.current.ownerRoomTransition) {
+        setUiPatch({ waitingError: getQueueErrorMessage('cancel', e) });
+      }
+      return false;
+    } finally {
+      setSyncPatch({ isCancelling: false });
+    }
+  }
+
+  function startOwnerPromptTimer(joinAttemptKey: string) {
+    stopOwnerPromptTimer('reschedule');
+    waitingTimerRef.current = setTimeout(() => {
+      if (activeJoinAttemptRef.current !== joinAttemptKey) return;
+      if (flowRef.current !== 'waiting') return;
+      setUiPatch({ ownerPrompt: true });
+      logFlow('ownerPrompt:show', { joinAttemptKey });
+    }, 20_000);
+    logFlow('timer:ownerPrompt:start', { joinAttemptKey });
+  }
+
+  function beginCooldown(left: number, pendingQueueKey: QueueKey | null) {
+    stopCooldownTimer('restart');
+    setFlow('cooldown');
+    setUiPatch({ showPostLeaveAd: true, postLeaveLeft: left, ownerPrompt: false, waitingError: null });
+    setSyncPatch({ pendingQueueKey, activeQueueKey: null });
+    logFlow('cooldown:start', { left, pendingQueueKey, cleanup: EVENT_CLEANUP_MATRIX.cooldown });
+
+    cooldownTimerRef.current = setInterval(() => {
+      setUi((prev) => {
+        if (prev.postLeaveLeft <= 1) {
+          stopCooldownTimer('finished');
+          try { localStorage.removeItem('amayadori_cd_until'); } catch {}
+          setTimeout(() => {
+            setUiPatch({ showPostLeaveAd: false, postLeaveLeft: 0 });
+            const pending = syncRef.current.pendingQueueKey;
+            setSyncPatch({ pendingQueueKey: null });
+            if (pending) {
+              void beginJoinFlow(pending, 'cooldown-resume');
+            } else {
+              setFlow('region');
+            }
+          }, 0);
+          return { ...prev, postLeaveLeft: 0 };
+        }
+        return { ...prev, postLeaveLeft: prev.postLeaveLeft - 1 };
+      });
+      return undefined as never;
+    }, 1000);
+  }
+
+  function startHeartbeat(entryId: string, joinAttemptKey: string) {
+    stopHeartbeat('reschedule');
+    const touch = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'touchEntry');
+    heartbeatTimerRef.current = setInterval(() => {
+      if (activeJoinAttemptRef.current !== joinAttemptKey) return;
+      touch({ entryId }).catch((err) => {
+        const code = getCallableCode(err);
+        console.warn('[touchEntry] callable failed', err);
+        if (!['failed-precondition', 'permission-denied', 'unavailable'].includes(code)) return;
+        clearQueueRuntime(`touch:${code}`);
+        if (flowRef.current === 'matched' || syncRef.current.ownerRoomTransition) return;
+        setFlow('waiting');
+        setUiPatch({
+          waitingMessage: '待機が中断されました。',
+          waitingError: getQueueErrorMessage('touch', err),
+          ownerPrompt: false,
+        });
+      });
+    }, 10_000);
+    logFlow('timer:heartbeat:start', { entryId, joinAttemptKey });
+  }
+
+  function handleEntrySnapshot(entryId: string, joinAttemptKey: string) {
+    detachEntryListener('replace');
+    entryUnsubRef.current = onSnapshot(doc(db, 'matchEntries', entryId), (snap) => {
+      if (activeJoinAttemptRef.current !== joinAttemptKey) return;
+      if (syncRef.current.ownerRoomTransition) return;
+      const d = snap.data() as ({ status?: MatchEntryStatus; roomId?: string; info?: string } & Record<string, unknown>) | undefined;
+      if (!d) return;
+
+      if (d.status === 'matched' && d.roomId) {
+        clearQueueRuntime('matched');
+        setFlow('matched');
+        logFlow('matched', { roomId: d.roomId, cleanup: EVENT_CLEANUP_MATRIX.matched });
+        router.push(`/chat?room=${encodeURIComponent(d.roomId)}`);
+        return;
+      }
+
+      if (d.info === 'paired_today') {
+        setUiPatch({ waitingMessage: '今日は同じ相手とは再マッチしません。別の相手を探しています…' });
+      } else if (d.info === 'waiting') {
+        setUiPatch({ waitingMessage: 'マッチング相手を探しています…' });
+      }
+
+      if (d.status === 'denied') {
+        clearQueueRuntime('denied');
+        setFlow('region');
+        setUiPatch({ waitingMessage: '今日は条件外でした', ownerPrompt: false });
+        return;
+      }
+
+      if (d.status === 'stale' || d.status === 'canceled' || d.status === 'expired') {
+        clearQueueRuntime(`terminal:${d.status}`);
+        if (flowRef.current === 'matched' || syncRef.current.ownerRoomTransition) return;
+        setFlow('waiting');
+        setUiPatch({
+          waitingMessage: '待機が中断されました。',
+          waitingError: '待機状態が終了したため、再度参加してください。',
+          ownerPrompt: false,
+        });
+      }
+    });
+    logFlow('listener:entry:attach', { entryId, joinAttemptKey });
+  }
+
+  async function enterQueue(queueKey: QueueKey, joinAttemptKey: string) {
+    const fn = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'enter');
+    const res = (await fn({ queueKey, profile: buildProfile() })) as any;
+    const entryId = res?.data?.entryId as string | undefined;
+    if (!entryId) throw new Error('enter returned without entryId');
+    if (activeJoinAttemptRef.current !== joinAttemptKey) return;
+
+    setFlow('waiting');
+    setSyncPatch({ activeEntryId: entryId, activeQueueKey: queueKey });
+    startHeartbeat(entryId, joinAttemptKey);
+    handleEntrySnapshot(entryId, joinAttemptKey);
+    startOwnerPromptTimer(joinAttemptKey);
+  }
+
+  async function beginJoinFlow(queueKey: QueueKey, source: 'user' | 'retry' | 'cooldown-resume' = 'user') {
+    const joinAttemptKey = `${queueKey}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+    activeJoinAttemptRef.current = joinAttemptKey;
+    clearQueueRuntime(`prejoin:${source}`);
+    setFlow('joining');
+    setSyncPatch({
+      activeQueueKey: queueKey,
+      lastJoinQueueKey: queueKey,
+      isRetryingJoin: true,
+      joinAttemptKey,
+    });
+    setUiPatch({
+      waitingMessage: 'マッチング相手を探しています...',
+      waitingError: null,
+      ownerPrompt: false,
+    });
+    logFlow('join:start', { queueKey, source, joinAttemptKey });
+
+    try {
+      const left = remainingCooldownSec();
+      if (left > 0) {
+        beginCooldown(left, queueKey);
+        return;
+      }
+
+      await ensureAnon();
+      await ensureIdTokenReady();
+      if (!auth.currentUser?.uid) throw new Error('auth unavailable');
+      await enterQueue(queueKey, joinAttemptKey);
+    } catch (e: any) {
+      console.error('[enter] failed', e);
+      const code = getCallableCode(e);
+      const retryAfterSec = Number(e?.details?.retryAfterSec ?? 0);
+      setFlow('waiting');
+      setUiPatch({
+        waitingMessage: '待機を開始できませんでした。',
+        waitingError: getQueueErrorMessage('join', e),
+        ownerPrompt: false,
+      });
+      if (code === 'resource-exhausted' && retryAfterSec > 0) {
+        try { localStorage.setItem('amayadori_cd_until', String(Date.now() + retryAfterSec * 1000)); } catch {}
+        beginCooldown(retryAfterSec, queueKey);
+      }
+    } finally {
+      setSyncPatch({ isRetryingJoin: false });
+    }
+  }
+
+  async function abortWaiting() {
+    const ok = await cancelCurrentEntry('abortWaiting');
+    if (ok) {
+      setFlow('region');
+      setUiPatch({ waitingError: null, ownerPrompt: false });
+    }
+  }
+
+  async function startOwnerRoomTransition() {
+    setSyncPatch({ ownerRoomTransition: true });
+    clearQueueRuntime('owner-transition');
+    setFlow('matched');
+    setUiPatch({ ownerPrompt: false, waitingError: null });
+    playDoor();
+    setRoomName('Cafe Amayadori');
+    setUserCount('オーナーとあなた');
+    setMsgs([]);
+    setShowSuggestions(false);
+    setTimeout(() => setFlow('chat'), 10);
+
+    await cancelCurrentEntry('owner-transition');
+
+    await ensureAnon();
+    try {
+      const fns = getFunctions(undefined, 'asia-northeast1');
+      const res = await httpsCallable(fns, 'startOwnerRoom')({ profile: buildProfile() }) as any;
+      const roomId = res?.data?.roomId as string | undefined;
+      if (roomId) {
+        setTimeout(() => { router.replace(`/chat?room=${encodeURIComponent(roomId)}`); }, 150);
+        return;
+      }
+    } catch (e) {
+      console.error('[startOwnerRoom] failed, fallback to mock', e);
+    } finally {
+      setSyncPatch({ ownerRoomTransition: false });
+    }
+
+    setTimeout(() => {
+      addOther('いらっしゃい。雨宿りかな？', 'オーナー', OWNER_ICON);
+      setTimeout(() => setShowSuggestions(true), 500);
+    }, 300);
+  }
+
+  function startRewardedWaitExtension() {
+    stopOwnerPromptTimer('rewarded');
+    stopRewardedTimer('reschedule');
+    setUiPatch({ ownerPrompt: false, showRewarded: true, rewardLeft: 5 });
+    rewardedTimerRef.current = setInterval(() => {
+      setUi((prev) => {
+        if (prev.rewardLeft <= 1) {
+          stopRewardedTimer('finished');
+          stopOwnerPromptTimer('rewarded-finished');
+          waitingTimerRef.current = setTimeout(() => {
+            setUiPatch({ waitingMessage: 'マッチング相手を探しています...', ownerPrompt: true });
+          }, 20_000);
+          return { ...prev, showRewarded: false, rewardLeft: 0, waitingMessage: 'もう少し待ってみます...' };
+        }
+        return { ...prev, rewardLeft: prev.rewardLeft - 1 };
+      });
+      return undefined as never;
+    }, 1000);
+  }
+
   function onPickIcon(file?: File) {
     if (!file) {
       setUserIcon('');
@@ -196,7 +552,6 @@ export default function Page() {
     reader.readAsDataURL(file);
   }
 
-  // プロフィール送信（保存して region へ）
   function submitProfile() {
     const nn = userNickname?.trim() ? userNickname : '名無しさん';
     const pf = userProfile?.trim() ? userProfile : '...';
@@ -207,376 +562,21 @@ export default function Page() {
       localStorage.setItem('amayadori_profile', pf);
       if (userIcon) localStorage.setItem('amayadori_icon', userIcon);
     } catch {}
-    setScreen('region');
+    setFlow('region');
   }
 
-  // クールダウン残り秒
-  function remainingCooldownSec(): number {
-    try {
-      const until = Number(localStorage.getItem('amayadori_cd_until') || '0');
-      const left = Math.ceil((until - Date.now()) / 1000);
-      return left > 0 ? left : 0;
-    } catch {
-      return 0;
-    }
+  function showInterstitialAd() {
+    setUiPatch({ showInterstitial: true });
   }
 
-  // 退室後広告の開始
-  function startPostLeaveAd(initialLeft?: number, autoJoinKey?: 'country' | 'global' | null) {
-    const left = typeof initialLeft === 'number' ? initialLeft : remainingCooldownSec() || POST_LEAVE_AD_SEC;
-    setPostLeaveLeft(left);
-    setShowPostLeaveAd(true);
-    setPendingQueueKey(autoJoinKey ?? null);
-    if (cdTimerRef.current) clearInterval(cdTimerRef.current);
-    cdTimerRef.current = setInterval(() => {
-      setPostLeaveLeft((v) => {
-        if (v <= 1) {
-          clearInterval(cdTimerRef.current);
-          setShowPostLeaveAd(false);
-          try { localStorage.removeItem('amayadori_cd_until'); } catch {}
-          if (pendingQueueKey) {
-            const key = pendingQueueKey;
-            setPendingQueueKey(null);
-            handleJoin(key);
-          }
-          return 0;
-        }
-        return v - 1;
-      });
-    }, 1000);
-  }
-
-  // ========= sendBeacon 用：ID トークンの保持と送信 =========
-  const idTokenRef = useRef<string | null>(null);
-  const beaconUrlRef = useRef<string>(resolveCancelBeaconUrl());
-
-  // auth のトークン更新を監視（匿名ログイン後も更新される）
-  useEffect(() => {
-    const unsub = auth.onIdTokenChanged(async (u) => {
-      if (u) {
-        try {
-          idTokenRef.current = await u.getIdToken(/* forceRefresh */ false);
-        } catch {
-          idTokenRef.current = null;
-        }
-      } else {
-        idTokenRef.current = null;
-      }
-    });
-    return () => unsub();
-  }, []);
-
-  // 明示的な取得（待機参加直後など、確実に用意しておく）
-  async function ensureIdTokenReady() {
-    await ensureAnon();
-    try {
-      idTokenRef.current = await auth.currentUser!.getIdToken(false);
-    } catch {
-      // noop
-    }
-  }
-
-  // sendBeacon（成功/失敗を返す）
-  function sendBeaconCancel(): boolean {
-    try {
-      const token = idTokenRef.current;
-      const url = beaconUrlRef.current;
-      if (!token || !url) return false;
-
-      if ('sendBeacon' in navigator) {
-        const body = new Blob(
-          [`idToken=${encodeURIComponent(token)}`],
-          { type: 'application/x-www-form-urlencoded; charset=UTF-8' }
-        );
-        return navigator.sendBeacon(url, body);
-      }
-    } catch {
-      // ignore
-    }
-    return false;
-  }
-  // ===============================================
-
-  // 待機のキャンセル（entryId が無くても必ずフォールバック実行）
-  async function cancelCurrentEntry() {
-    if (isCancelling) return false;
-    setIsCancelling(true);
-    try {
-      await ensureAnon();
-      const fns = getFunctions(undefined, 'asia-northeast1');
-      const id = entryIdRef.current;
-
-      if (id) {
-        await httpsCallable(fns, 'cancelEntry')({ entryId: id });
-      } else {
-        await httpsCallable(fns, 'cancelMyQueuedEntries')({});
-      }
-
-      entryIdRef.current = null;
-      if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-      if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
-      setWaitingError(null);
-      return true;
-    } catch (e: any) {
-      const code = getCallableCode(e);
-      if (code !== 'failed-precondition') {
-        console.error('[cancelCurrentEntry] failed', e);
-        setWaitingError(getQueueErrorMessage('cancel', e));
-        return false;
-      }
-
-      entryIdRef.current = null;
-      if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-      if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
-      setWaitingError(null);
-      return true;
-    } finally {
-      setIsCancelling(false);
-    }
-  }
-
-  // ★ タブ/ウインドウを閉じる・他サイトへ遷移・リロードなど「ページを離れる」時だけ発火
-  useEffect(() => {
-    const onPageHide = () => {
-      if (!isWaitingRef.current) return;
-
-      // まず Beacon（最も成功しやすい）
-      const ok = sendBeaconCancel();
-      if (ok) return;
-
-      // フォールバック：keepalive fetch（レスポンスは読まない）
-      try {
-        const token = idTokenRef.current;
-        const url = beaconUrlRef.current;
-        if (!token || !url) return;
-        fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: `idToken=${encodeURIComponent(token)}`,
-          keepalive: true,
-          mode: 'no-cors',
-        });
-      } catch {
-        // ignore
-      }
-    };
-
-    window.addEventListener('pagehide', onPageHide);
-    return () => {
-      window.removeEventListener('pagehide', onPageHide);
-    };
-  }, []);
-
-  // エントランス到達時、残CDがあれば広告表示
-  useEffect(() => {
-    const left = remainingCooldownSec();
-    if (left > 0) startPostLeaveAd(left, null);
-    return () => {
-      if (cdTimerRef.current) clearInterval(cdTimerRef.current);
-    };
-  }, []);
-
-  // ▼ 待機キュー参加：プロフィール同梱 + ハートビート & キャンセル ▼
-  async function handleJoin(queueKey: 'country' | 'global') {
-    setLastJoinQueueKey(queueKey);
-    setIsRetryingJoin(true);
-    try {
-      const left = remainingCooldownSec();
-      if (left > 0) {
-        startPostLeaveAd(left, queueKey);
-        return;
-      }
-
-      await ensureAnon();
-      await ensureIdTokenReady();
-      const uid = auth.currentUser?.uid;
-      if (!uid) throw new Error('auth unavailable');
-
-      setOwnerPrompt(false);
-      setWaitingError(null);
-      setWaitingMessage('マッチング相手を探しています...');
-      setScreen('waiting');
-
-      if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
-      if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-      entryIdRef.current = null;
-
-      const fn = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'enter');
-      const profile = {
-        nickname: userNickname || localStorage.getItem('amayadori_nickname') || 'あなた',
-        profile: userProfile || localStorage.getItem('amayadori_profile') || '...',
-        icon: userIcon || localStorage.getItem('amayadori_icon') || DEFAULT_USER_ICON,
-      };
-
-      const res = (await fn({ queueKey, profile })) as any;
-      const entryId = res?.data?.entryId as string | undefined;
-      if (!entryId) {
-        throw new Error('enter returned without entryId');
-      }
-
-      entryIdRef.current = entryId;
-
-      const touch = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'touchEntry');
-      heartbeatTimerRef.current = setInterval(() => {
-        const id = entryIdRef.current;
-        if (!id) return;
-        touch({ entryId: id }).catch((err) => {
-          const code = getCallableCode(err);
-          console.warn('[touchEntry] callable failed', err);
-          if (code === 'failed-precondition' || code === 'permission-denied' || code === 'unavailable') {
-            if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-            entryIdRef.current = null;
-            setWaitingMessage('待機が中断されました。');
-            setWaitingError(getQueueErrorMessage('touch', err));
-            setOwnerPrompt(false);
-          }
-        });
-      }, 10_000);
-
-      entryUnsubRef.current = onSnapshot(doc(db, 'matchEntries', entryId), (snap) => {
-        // ★ オーナー遷移中は待機UIを更新しない（「中断されました」等を出さない）
-        if (ownerSwitchingRef.current) return;
-
-        const d = snap.data() as any | undefined;
-        if (!d) return;
-        if (d.status === 'matched' && d.roomId) {
-          // 片付けてルームへ
-          if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
-          if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-          entryIdRef.current = null;
-          router.push(`/chat?room=${encodeURIComponent(d.roomId)}`);
-        }
-        if (d.info === 'paired_today') setWaitingMessage('今日は同じ相手とは再マッチしません。別の相手を探しています…');
-        else if (d.info === 'waiting') setWaitingMessage('マッチング相手を探しています…');
-        if (d.status === 'denied') {
-          setWaitingMessage('今日は条件外でした');
-          setTimeout(() => setScreen('region'), 2000);
-        }
-        if (d.status === 'stale' || d.status === 'canceled' || d.status === 'expired') {
-          setWaitingMessage('待機が中断されました。');
-          setWaitingError('待機状態が終了したため、再度参加してください。');
-          setOwnerPrompt(false);
-          if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-          entryIdRef.current = null;
-        }
-      });
-
-      if (waitingTimerRef.current) clearTimeout(waitingTimerRef.current);
-      waitingTimerRef.current = setTimeout(() => setOwnerPrompt(true), 20000);
-    } catch (e: any) {
-      console.error('[enter] failed', e);
-      const code = getCallableCode(e);
-      const retryAfterSec = Number(e?.details?.retryAfterSec ?? 0);
-      setWaitingMessage('待機を開始できませんでした。');
-      setWaitingError(getQueueErrorMessage('join', e));
-      setOwnerPrompt(false);
-      if (code === 'resource-exhausted' && retryAfterSec > 0) {
-        try { localStorage.setItem('amayadori_cd_until', String(Date.now() + retryAfterSec * 1000)); } catch {}
-        startPostLeaveAd(retryAfterSec, queueKey);
-        return;
-      }
-      setScreen('waiting');
-    } finally {
-      setIsRetryingJoin(false);
-    }
-  }
-
-//  // 待機 → オーナー（モック）に切り替えるときは必ずキャンセル
-  async function startChatWithOwner() {
-    // ★ オーナー遷移モード開始：以降、待機UI更新は抑止
-    ownerSwitchingRef.current = true;
-
-    // ★ 先に待機関連を停止（購読・HB・提案表示を止める）
-    if (waitingTimerRef.current) clearTimeout(waitingTimerRef.current);
-    setOwnerPrompt(false);
-    if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
-    if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-
-    // （体感を速く）扉アニメを先に開始
-    playDoor();
-
-    // ★ ここで即座にローカルのチャットUIへ切替（見た目だけ先に）
-    setRoomName('Cafe Amayadori');
-    setUserCount('オーナーとあなた');
-    setMsgs([]);
-    setShowSuggestions(false);
-    setTimeout(() => { setScreen('chat'); }, 10);
-
-    // ★ サーバ側のキューを裏で確実に解除（UIはもう待機に戻さない）
-    await cancelCurrentEntry();
-
-    await ensureAnon();
-    try {
-      const fns = getFunctions(undefined, 'asia-northeast1');
-      const profile = {
-        nickname: userNickname || localStorage.getItem('amayadori_nickname') || 'あなた',
-        profile:  userProfile  || localStorage.getItem('amayadori_profile')  || '...',
-        icon:     userIcon     || localStorage.getItem('amayadori_icon')     || DEFAULT_USER_ICON,
-      };
-      const res = await httpsCallable(fns, 'startOwnerRoom')({ profile }) as any;
-      const roomId = res?.data?.roomId as string | undefined;
-
-      if (roomId) {
-        // 扉アニメとの整合のためにごく短い遅延ののち、本番チャットに遷移
-        setTimeout(() => { router.replace(`/chat?room=${encodeURIComponent(roomId)}`); }, 150);
-        return;
-      }
-    } catch (e) {
-      console.error('[startOwnerRoom] failed, fallback to mock', e);
-    } finally {
-      // このページに留まる場合のみ解除（/chat に遷移すればアンマウントされる）
-      ownerSwitchingRef.current = false;
-    }
-
-    // ★ フォールバック（万一Functions不調時のみ）：ローカルのオーナー会話を開始
-    setTimeout(() => {
-      addOther('いらっしゃい。雨宿りかな？', 'オーナー', OWNER_ICON);
-      setTimeout(() => setShowSuggestions(true), 500);
-    }, 300);
- }
-
-  // 待機をやめる（ボタン）
-  async function abortWaiting() {
-    const ok = await cancelCurrentEntry();
-    if (ok) setScreen('region');
-  }
-
-  // ダミー広告（リワード）
-  function showRewardedAd() {
-    if (waitingTimerRef.current) clearTimeout(waitingTimerRef.current);
-    setOwnerPrompt(false);
-    setShowRewarded(true);
-    setRewardLeft(5);
-    const timer = setInterval(() => {
-      setRewardLeft((v) => {
-        if (v <= 1) {
-          clearInterval(timer);
-          setShowRewarded(false);
-          waitLonger();
-        }
-        return v - 1;
-      });
-    }, 1000);
-  }
-  function waitLonger() {
-    setWaitingMessage('もう少し待ってみます...');
-    waitingTimerRef.current = setTimeout(() => {
-      setWaitingMessage('マッチング相手を探しています...');
-      setOwnerPrompt(true);
-    }, 20000);
-  }
-
-  // 既存インタースティシャル（ダミー）
-  function showInterstitialAd() { setShowInterstitial(true); }
   function closeInterstitial() {
-    setShowInterstitial(false);
+    setUiPatch({ showInterstitial: false });
     setMsgs([]);
     setShowSuggestions(false);
     setDoorOpen(false);
-    setScreen('profile');
+    setFlow('profile');
   }
 
-  // チャット送信（モック）
   function send() {
     const text = draft.trim();
     if (!text) return;
@@ -590,42 +590,130 @@ export default function Page() {
         'どんな音楽が好き？リクエストがあればかけるよ。',
         '外の音を聞いていると、落ち着くんだ。',
       ];
-      const t = replies[Math.floor(Math.random() * replies.length)];
-      addOther(t, 'オーナー', OWNER_ICON);
+      addOther(replies[Math.floor(Math.random() * replies.length)], 'オーナー', OWNER_ICON);
     }, 800 + Math.random() * 500);
   }
+
   function addMe(text: string) {
-    setMsgs((m) => [
-      ...m,
-      { id: (crypto as any).randomUUID ? crypto.randomUUID() : String(Date.now() + Math.random()), text, isMe: true },
-    ]);
-  }
-  function addOther(text: string, nick: string, icon: string) {
-    setMsgs((m) => [
-      ...m,
-      {
-        id: (crypto as any).randomUUID ? crypto.randomUUID() : String(Date.now() + Math.random()),
-        text,
-        isMe: false,
-        nickname: nick,
-        icon,
-      },
-    ]);
+    setMsgs((m) => [...m, { id: crypto.randomUUID(), text, isMe: true }]);
   }
 
-  // 画面破棄時のクリーンアップ（キャンセルは行わない：SPA 内遷移で誤キャンセルを避ける）
+  function addOther(text: string, nickname: string, icon: string) {
+    setMsgs((m) => [...m, { id: crypto.randomUUID(), text, isMe: false, nickname, icon }]);
+  }
+
   useEffect(() => {
+    try {
+      const nn = localStorage.getItem('amayadori_nickname');
+      const pf = localStorage.getItem('amayadori_profile');
+      const ic = localStorage.getItem('amayadori_icon');
+      if (nn) setUserNickname(nn);
+      if (pf) setUserProfile(pf);
+      if (ic) setUserIcon(ic);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (sentAmayadoriPV.current) return;
+    sentAmayadoriPV.current = true;
+    (async () => {
+      try {
+        await ensureAnon();
+        await httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'trackVisit')({
+          page: 'amayadori',
+          src: typeof document !== 'undefined' ? document.referrer : '',
+        });
+      } catch {
+        // noop
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const arr: Drop[] = Array.from({ length: 100 }).map((_, i) => ({
+      i,
+      x: Math.random() * 100,
+      delay: Math.random() * 2,
+      duration: 0.5 + Math.random() * 0.5,
+      width: 1 + Math.random() * 2,
+      height: 60 + Math.random() * 40,
+    }));
+    setDrops(arr);
+  }, []);
+
+  useEffect(() => {
+    const unsub = auth.onIdTokenChanged(async (u) => {
+      if (!u) {
+        idTokenRef.current = null;
+        return;
+      }
+      try {
+        idTokenRef.current = await u.getIdToken(false);
+      } catch {
+        idTokenRef.current = null;
+      }
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    const onPageHide = () => {
+      if (!isWaitingFlow) return;
+      const ok = sendBeaconCancel();
+      if (ok) return;
+      try {
+        const token = idTokenRef.current;
+        const url = beaconUrlRef.current;
+        if (!token || !url) return;
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `idToken=${encodeURIComponent(token)}`,
+          keepalive: true,
+          mode: 'no-cors',
+        });
+      } catch {
+        // noop
+      }
+    };
+    window.addEventListener('pagehide', onPageHide);
+    return () => window.removeEventListener('pagehide', onPageHide);
+  }, [isWaitingFlow]);
+
+  useEffect(() => {
+    const left = remainingCooldownSec();
+    if (left > 0) {
+      stopCooldownTimer('mount-restart');
+      setFlow('cooldown');
+      setUiPatch({ showPostLeaveAd: true, postLeaveLeft: left, ownerPrompt: false, waitingError: null });
+      setSyncPatch({ pendingQueueKey: null, activeQueueKey: null });
+      cooldownTimerRef.current = setInterval(() => {
+        setUi((prev) => {
+          if (prev.postLeaveLeft <= 1) {
+            stopCooldownTimer('finished');
+            try { localStorage.removeItem('amayadori_cd_until'); } catch {}
+            setTimeout(() => {
+              setUiPatch({ showPostLeaveAd: false, postLeaveLeft: 0 });
+              setFlow('region');
+            }, 0);
+            return { ...prev, postLeaveLeft: 0 };
+          }
+          return { ...prev, postLeaveLeft: prev.postLeaveLeft - 1 };
+        });
+        return undefined as never;
+      }, 1000);
+    }
     return () => {
-      if (waitingTimerRef.current) clearTimeout(waitingTimerRef.current);
-      if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null; }
-      if (entryUnsubRef.current) { entryUnsubRef.current(); entryUnsubRef.current = null; }
-      if (cdTimerRef.current) clearInterval(cdTimerRef.current);
+      stopOwnerPromptTimer('unmount');
+      stopHeartbeat('unmount');
+      stopCooldownTimer('unmount');
+      stopRewardedTimer('unmount');
+      detachEntryListener('unmount');
     };
   }, []);
 
   return (
     <div className="w-full h-full overflow-hidden">
-      {/* 雨アニメーション（SSRとCSRの差異許容） */}
       <div id="rain-container" suppressHydrationWarning>
         {drops.map((d) => (
           <div
@@ -642,68 +730,38 @@ export default function Page() {
         ))}
       </div>
 
-      {/* メイン */}
       <div id="app-container" className="relative z-10 w-full h-full flex items-center justify-center p-4">
-        {/* プロフィール */}
-        {screen === 'profile' && (
+        {flow === 'profile' && (
           <div id="profile-screen" className="w-full max-w-sm">
             <div className="glass-card p-8 text-center space-y-6 fade-in">
               <h1 className="text-3xl font-bold tracking-wider">Amayadori</h1>
               <p className="text-sm text-gray-400">雨がやむまで、少しだけ。</p>
               <div className="flex justify-center">
                 <label className="cursor-pointer">
-                  <img
-                    className="w-28 h-28 rounded-full object-cover border-4 border-dashed border-gray-500 hover:border-gray-400 transition-all"
-                    src={userIcon || DEFAULT_USER_ICON}
-                    alt="icon preview"
-                  />
-                  <input
-                    type="file"
-                    accept="image/*"
-                    className="hidden"
-                    onChange={(e) => onPickIcon(e.target.files?.[0] || undefined)}
-                  />
+                  <img className="w-28 h-28 rounded-full object-cover border-4 border-dashed border-gray-500 hover:border-gray-400 transition-all" src={userIcon || DEFAULT_USER_ICON} alt="icon preview" />
+                  <input type="file" accept="image/*" className="hidden" onChange={(e) => onPickIcon(e.target.files?.[0] || undefined)} />
                 </label>
               </div>
-              <input
-                type="text"
-                className="w-full px-4 py-3 input-glass"
-                placeholder="ニックネーム"
-                value={userNickname === 'あなた' ? '' : userNickname}
-                onChange={(e) => setUserNickname(e.target.value)}
-              />
-              <textarea
-                className="w-full px-4 py-3 input-glass h-24 resize-none"
-                placeholder="ひとことプロフィール"
-                value={userProfile === '...' ? '' : userProfile}
-                onChange={(e) => setUserProfile(e.target.value)}
-              />
-              <button onClick={submitProfile} className="w-full text-white font-bold py-3 px-4 rounded-xl btn-gradient">
-                次へ
-              </button>
+              <input type="text" className="w-full px-4 py-3 input-glass" placeholder="ニックネーム" value={userNickname === 'あなた' ? '' : userNickname} onChange={(e) => setUserNickname(e.target.value)} />
+              <textarea className="w-full px-4 py-3 input-glass h-24 resize-none" placeholder="ひとことプロフィール" value={userProfile === '...' ? '' : userProfile} onChange={(e) => setUserProfile(e.target.value)} />
+              <button onClick={submitProfile} className="w-full text-white font-bold py-3 px-4 rounded-xl btn-gradient">次へ</button>
             </div>
           </div>
         )}
 
-        {/* 国/グローバル選択 */}
-        {screen === 'region' && (
+        {flow === 'region' && (
           <div id="region-selection-screen" className="w-full max-w-sm">
             <div className="glass-card p-8 text-center space-y-6 fade-in">
               <h2 className="text-2xl font-bold">どちらのカフェへ？</h2>
               <p className="text-sm text-gray-400">雨宿りの場所を選んでください。</p>
               <div className="space-y-4">
-                <button className="w-full text-white font-bold py-3 px-4 rounded-xl btn-gradient" onClick={() => handleJoin('country')}>
+                <button className="w-full text-white font-bold py-3 px-4 rounded-xl btn-gradient" onClick={() => void beginJoinFlow('country')}>
                   同じ国の人と
                 </button>
-                <button className="w-full text白 font-bold py-3 px-4 rounded-xl btn-secondary" onClick={() => handleJoin('global')}>
+                <button className="w-full text-white font-bold py-3 px-4 rounded-xl btn-secondary" onClick={() => void beginJoinFlow('global')}>
                   世界中の誰かと
                 </button>
-
-                {/* ネイティブ広告（ダミー） */}
-                <div
-                  className="p-3 rounded-xl border border-dashed border-yellow-500/50 text-left cursor-pointer hover:bg-yellow-500/10 transition-colors"
-                  onClick={() => setCustomAlert('【PR】特別な夜のカフェへのご招待です。詳細はWebサイトをご覧ください。')}
-                >
+                <div className="p-3 rounded-xl border border-dashed border-yellow-500/50 text-left cursor-pointer hover:bg-yellow-500/10 transition-colors" onClick={() => setUiPatch({ customAlert: '【PR】特別な夜のカフェへのご招待です。詳細はWebサイトをご覧ください。' })}>
                   <p className="text-xs text-yellow-500 font-bold">【PR】</p>
                   <p className="font-semibold text-white">星降る夜のカフェへご招待</p>
                   <p className="text-sm text-gray-400">今夜だけの特別な体験を。</p>
@@ -713,61 +771,37 @@ export default function Page() {
           </div>
         )}
 
-        {/* 待機 */}
-        {screen === 'waiting' && (
+        {(flow === 'joining' || flow === 'waiting') && (
           <div id="waiting-screen" className="w-full max-w-sm text-center">
             <div className="glass-card p-8 space-y-6 fade-in">
-              <div className="flex justify-center items-center">
-                <div className="spinner w-12 h-12 rounded-full border-4"></div>
-              </div>
-              <h2 id="waiting-message" className="text-2xl font-bold">{waitingMessage}</h2>
+              <div className="flex justify-center items-center"><div className="spinner w-12 h-12 rounded-full border-4"></div></div>
+              <h2 id="waiting-message" className="text-2xl font-bold">{flow === 'joining' ? '待機を開始しています...' : ui.waitingMessage}</h2>
               <p className="text-sm text-gray-400">雨の中、誰かが来るのを待っています。</p>
 
-              {waitingError && (
+              {ui.waitingError && (
                 <div className="rounded-xl border border-red-400/40 bg-red-500/10 p-4 text-left text-sm text-red-100 space-y-3">
-                  <p>{waitingError}</p>
+                  <p>{ui.waitingError}</p>
                   <div className="flex flex-col gap-2 sm:flex-row">
-                    <button
-                      className="rounded-lg bg-white/10 px-4 py-2 font-semibold text-white disabled:opacity-50"
-                      onClick={() => lastJoinQueueKey && handleJoin(lastJoinQueueKey)}
-                      disabled={!lastJoinQueueKey || isRetryingJoin || isCancelling}
-                    >
-                      {isRetryingJoin ? '再試行中...' : 'もう一度試す'}
+                    <button className="rounded-lg bg-white/10 px-4 py-2 font-semibold text-white disabled:opacity-50" onClick={() => syncState.lastJoinQueueKey && void beginJoinFlow(syncState.lastJoinQueueKey, 'retry')} disabled={!syncState.lastJoinQueueKey || syncState.isRetryingJoin || syncState.isCancelling}>
+                      {syncState.isRetryingJoin ? '再試行中...' : 'もう一度試す'}
                     </button>
-                    <button
-                      className="rounded-lg border border-white/20 px-4 py-2 text-white/90"
-                      onClick={() => setScreen('region')}
-                      disabled={isCancelling}
-                    >
+                    <button className="rounded-lg border border-white/20 px-4 py-2 text-white/90" onClick={() => setFlow('region')} disabled={syncState.isCancelling}>
                       エントランスへ戻る
                     </button>
                   </div>
                 </div>
               )}
 
-              {/* 待機をやめる */}
-              <button
-                className="mt-2 text-sm text-gray-300 underline disabled:opacity-50"
-                onClick={abortWaiting}
-                disabled={isCancelling}
-              >
-                {isCancelling ? 'キャンセル中...' : '待機をやめて戻る'}
+              <button className="mt-2 text-sm text-gray-300 underline disabled:opacity-50" onClick={() => void abortWaiting()} disabled={syncState.isCancelling}>
+                {syncState.isCancelling ? 'キャンセル中...' : '待機をやめて戻る'}
               </button>
 
-              {ownerPrompt && (
+              {ui.ownerPrompt && (
                 <div id="owner-prompt-modal" className="fade-in pt-4 mt-4 border-t border-gray-700/50">
-                  <p className="mb-4">
-                    雨宿りのお客様がいないようです。
-                    <br />
-                    カフェのオーナーと話をしますか？
-                  </p>
+                  <p className="mb-4">雨宿りのお客様がいないようです。<br />カフェのオーナーと話をしますか？</p>
                   <div className="flex flex-col sm:flex-row justify-center gap-4">
-                    <button onClick={startChatWithOwner} className="text-white font-bold py-2 px-6 rounded-lg btn-gradient">
-                      話す
-                    </button>
-                    <button onClick={showRewardedAd} className="text-white font-bold py-2 px-6 rounded-lg btn-secondary">
-                      広告を見て待つ
-                    </button>
+                    <button onClick={() => void startOwnerRoomTransition()} className="text-white font-bold py-2 px-6 rounded-lg btn-gradient">話す</button>
+                    <button onClick={startRewardedWaitExtension} className="text-white font-bold py-2 px-6 rounded-lg btn-secondary">広告を見て待つ</button>
                   </div>
                 </div>
               )}
@@ -775,8 +809,7 @@ export default function Page() {
           </div>
         )}
 
-        {/* チャット（モック） */}
-        {screen === 'chat' && (
+        {flow === 'chat' && (
           <div id="chat-screen" className="w-full h-full flex flex-col glass-card">
             <header className="w-full p-4 border-b border-gray-700/50 flex items-center justify-between flex-shrink-0">
               <div className="flex items-center space-x-3">
@@ -791,152 +824,75 @@ export default function Page() {
                   <h2 id="room-name" className="text-lg font-bold">{roomName}</h2>
                   <p id="user-count" className="text-sm text-gray-400">{userCount}</p>
                 </div>
-                <button id="end-chat-button" className="btn-exit" onClick={showInterstitialAd}>
-                  退室
-                </button>
+                <button id="end-chat-button" className="btn-exit" onClick={showInterstitialAd}>退室</button>
               </div>
             </header>
-
             <main id="chat-messages" className="flex-1 p-4 overflow-y-auto flex flex-col space-y-4">
               {msgs.map((m) => (
                 <div key={m.id} className={`flex items-end gap-2 ${m.isMe ? 'justify-end' : 'justify-start'}`}>
-                  {!m.isMe && (
-                    <img
-                      className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                      src={m.icon || OWNER_ICON}
-                      alt=""
-                      onError={(e) => { (e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON; }}
-                    />
-                  )}
+                  {!m.isMe && <img className="w-8 h-8 rounded-full object-cover flex-shrink-0" src={m.icon || OWNER_ICON} alt="" onError={(e) => { (e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON; }} />}
                   <div className={`chat-bubble ${m.isMe ? 'me' : 'other'}`}>
                     {!m.isMe && <span className="block text-xs font-bold mb-1 text-purple-300">{m.nickname || 'オーナー'}</span>}
                     <p>{m.text}</p>
                   </div>
-                  {m.isMe && (
-                    <img
-                      className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                      src={userIcon || DEFAULT_USER_ICON}
-                      alt=""
-                      onError={(e) => { (e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON; }}
-                    />
-                  )}
+                  {m.isMe && <img className="w-8 h-8 rounded-full object-cover flex-shrink-0" src={userIcon || DEFAULT_USER_ICON} alt="" onError={(e) => { (e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON; }} />}
                 </div>
               ))}
             </main>
-
             <footer className="p-4 flex-shrink-0">
               {showSuggestions && (
                 <div id="suggestion-area" className="flex-wrap justify-center gap-2 mb-3 flex">
                   {conversationStarters.slice(0, 3).map((t) => (
-                    <button
-                      key={t}
-                      className="suggestion-btn"
-                      onClick={() => {
-                        setDraft(t);
-                        setShowSuggestions(false);
-                        setTimeout(() => taRef.current?.focus(), 0);
-                      }}
-                    >
-                      {t}
-                    </button>
+                    <button key={t} className="suggestion-btn" onClick={() => { setDraft(t); setShowSuggestions(false); setTimeout(() => taRef.current?.focus(), 0); }}>{t}</button>
                   ))}
                 </div>
               )}
               <div className="flex items-center space-x-3">
-                <textarea
-                  id="message-input"
-                  ref={taRef}
-                  className="flex-1 px-4 py-3 message-textarea"
-                  placeholder="メッセージを送信..."
-                  rows={1}
-                  value={draft}
-                  onChange={(e) => {
-                    setDraft(e.target.value);
-                    autoResize();
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      send();
-                    }
-                  }}
-                />
-                <button
-                  id="send-button"
-                  className="w-12 h-12 rounded-full text-white flex items-center justify-center btn-gradient flex-shrink-0"
-                  onClick={send}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-                    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <line x1="22" y1="2" x2="11" y2="13"></line>
-                    <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-                  </svg>
-                </button>
+                <textarea id="message-input" ref={taRef} className="flex-1 px-4 py-3 message-textarea" placeholder="メッセージを送信..." rows={1} value={draft} onChange={(e) => { setDraft(e.target.value); autoResize(); }} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } }} />
+                <button id="send-button" className="w-12 h-12 rounded-full text-white flex items-center justify-center btn-gradient flex-shrink-0" onClick={send}><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg></button>
               </div>
             </footer>
           </div>
         )}
       </div>
 
-      {/* 扉アニメーション */}
-      <div
-        id="door-animation"
-        className={`fixed inset-0 z-50 flex pointer-events-none ${doorOpen ? 'open' : ''} ${doorOpen ? '' : 'hidden'}`}
-      >
-        <div className="door left"></div>
-        <div className="door right"></div>
-      </div>
+      <div id="door-animation" className={`fixed inset-0 z-50 flex pointer-events-none ${doorOpen ? 'open' : ''} ${doorOpen ? '' : 'hidden'}`}><div className="door left"></div><div className="door right"></div></div>
 
-      {/* 既存のダミー・インタースティシャル */}
-      {showInterstitial && (
+      {ui.showInterstitial && (
         <div id="interstitial-ad-screen" className="fixed inset-0 bg-black/80 z-50 flex-col items-center justify-center flex">
           <div className="bg-gray-800 p-4 rounded-lg text-center">
             <p className="text-sm text-gray-400">広告</p>
-            <div className="w-72 h-96 bg-gray-700 my-2 flex items中心 justify-center">
-              <p>インタースティシャル広告（ダミー）</p>
-            </div>
-            <button id="close-interstitial-ad" className="mt-2 text-sm text-blue-400" onClick={() => closeInterstitial()}>
-              広告を閉じる
-            </button>
+            <div className="w-72 h-96 bg-gray-700 my-2 flex items-center justify-center"><p>インタースティシャル広告（ダミー）</p></div>
+            <button id="close-interstitial-ad" className="mt-2 text-sm text-blue-400" onClick={closeInterstitial}>広告を閉じる</button>
           </div>
         </div>
       )}
 
-      {showRewarded && (
+      {ui.showRewarded && (
         <div id="rewarded-ad-screen" className="fixed inset-0 bg-black/80 z-50 flex-col items-center justify-center flex">
           <div className="glass-card p-8 text-center space-y-4">
             <div className="spinner w-12 h-12 rounded-full border-4 mx-auto"></div>
             <h2 className="text-xl font-bold">リワード広告を視聴中...</h2>
-            <p id="reward-timer" className="text-lg">{rewardLeft}</p>
+            <p id="reward-timer" className="text-lg">{ui.rewardLeft}</p>
           </div>
         </div>
       )}
 
-      {/* カスタムアラート（PR） */}
-      {customAlert && (
+      {ui.customAlert && (
         <div id="custom-alert" className="fixed inset-0 bg-black/80 z-50 items-center justify-center flex">
           <div className="glass-card p-8 text-center space-y-4 max-w-sm mx-4">
-            <p id="custom-alert-message">{customAlert}</p>
-            <button
-              id="custom-alert-close"
-              className="mt-4 text-white font-bold py-2 px-6 rounded-lg btn-secondary"
-              onClick={() => setCustomAlert(null)}
-            >
-              閉じる
-            </button>
+            <p id="custom-alert-message">{ui.customAlert}</p>
+            <button id="custom-alert-close" className="mt-4 text-white font-bold py-2 px-6 rounded-lg btn-secondary" onClick={() => setUiPatch({ customAlert: null })}>閉じる</button>
           </div>
         </div>
       )}
 
-      {/* 退室後広告（別タブ再入室対策） */}
-      {showPostLeaveAd && (
+      {ui.showPostLeaveAd && (
         <div className="fixed inset-0 z-[60] bg-black/80 flex items-center justify-center">
           <div className="glass-card p-6 w-full max-w-md text-center space-y-4">
             <p className="text-sm text-gray-400">広告</p>
-            <div className="w-full h-96 bg-gray-700/80 rounded-xl flex items-center justify-center">
-              <p className="px-6">ここにインタースティシャル広告（SDK/タグ）を差し込み</p>
-            </div>
-            <p className="text-gray-300">閉じるまで {postLeaveLeft} 秒</p>
+            <div className="w-full h-96 bg-gray-700/80 rounded-xl flex items-center justify-center"><p className="px-6">ここにインタースティシャル広告（SDK/タグ）を差し込み</p></div>
+            <p className="text-gray-300">閉じるまで {ui.postLeaveLeft} 秒</p>
           </div>
         </div>
       )}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -13,183 +13,114 @@ import {
   serverTimestamp,
   Timestamp,
 } from 'firebase/firestore';
-import { httpsCallable, getFunctions } from 'firebase/functions';
+import { getFunctions, httpsCallable } from 'firebase/functions';
 import { auth, db, ensureAnon } from '@/lib/firebase';
 
-const DEFAULT_USER_ICON =
-  'https://storage.googleapis.com/amayadori/defaultIcon.png';
-const OWNER_ICON =
-  'https://storage.googleapis.com/amayadori/cafeownerIcon.png';
+const DEFAULT_USER_ICON = 'https://storage.googleapis.com/amayadori/defaultIcon.png';
+const OWNER_ICON = 'https://storage.googleapis.com/amayadori/cafeownerIcon.png';
+const POST_LEAVE_AD_SEC = Number(process.env.NEXT_PUBLIC_POST_LEAVE_AD_SECONDS ?? 20);
 
+type ChatPhase = 'joining' | 'matched' | 'leaving' | 'cooldown';
 type ChatMsg = { id: string; text: string; uid: string; system?: boolean; createdAt?: Timestamp };
 type ProfileSnap = { nickname?: string; profile?: string; icon?: string };
 type Drop = { i: number; x: number; delay: number; duration: number; width: number; height: number };
 
-const POST_LEAVE_AD_SEC = Number(process.env.NEXT_PUBLIC_POST_LEAVE_AD_SECONDS ?? 20);
+type ChatUiState = {
+  showLeaveConfirm: boolean;
+  showPostLeaveAd: boolean;
+  postLeaveLeft: number;
+  peerLeftNotice: boolean;
+};
+
+type ChatSyncState = {
+  members: string[];
+  profiles: Record<string, ProfileSnap>;
+  msgs: ChatMsg[];
+  myUid: string;
+  hasStartedLeave: boolean;
+};
+
+function logChat(label: string, payload?: Record<string, unknown>) {
+  console.info(`[chat:${label}]`, payload ?? {});
+}
 
 function ChatPageInner() {
   const r = useRouter();
   const sp = useSearchParams();
   const roomId = sp.get('room') || '';
 
-  const [myUid, setMyUid] = useState<string>('');
-  const [profiles, setProfiles] = useState<Record<string, ProfileSnap>>({});
-  const [members, setMembers] = useState<string[]>([]);
-  const [msgs, setMsgs] = useState<ChatMsg[]>([]);
+  const [phase, setPhase] = useState<ChatPhase>('joining');
+  const [doorOpen, setDoorOpen] = useState(false);
   const [draft, setDraft] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(true);
   const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [peerLeftNotice, setPeerLeftNotice] = useState(false);
-
-  const [doorOpen, setDoorOpen] = useState(false);
-  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
-  const [showPostLeaveAd, setShowPostLeaveAd] = useState(false);
-  const [postLeaveLeft, setPostLeaveLeft] = useState<number>(POST_LEAVE_AD_SEC);
-  const adTimerRef = useRef<any>(null);
+  const [ui, setUi] = useState<ChatUiState>({
+    showLeaveConfirm: false,
+    showPostLeaveAd: false,
+    postLeaveLeft: POST_LEAVE_AD_SEC,
+    peerLeftNotice: false,
+  });
+  const [syncState, setSyncState] = useState<ChatSyncState>({
+    members: [],
+    profiles: {},
+    msgs: [],
+    myUid: '',
+    hasStartedLeave: false,
+  });
+  const [drops, setDrops] = useState<Drop[]>([]);
+  const sentChatPV = useRef(false);
+  const adTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
-  // 💧 雨アニメ：マウント後に生成（SSR差分を避ける）
-  const [drops, setDrops] = useState<Drop[]>([]);
-  useEffect(() => {
-    const arr: Drop[] = Array.from({ length: 100 }).map((_, i) => {
-      const x = Math.random() * 100;
-      const delay = Math.random() * 2;
-      const duration = 0.5 + Math.random() * 0.5;
-      const width = 1 + Math.random() * 2;
-      const height = 60 + Math.random() * 40;
-      return { i, x, delay, duration, width, height };
-    });
-    setDrops(arr);
-  }, []);
+  const members = syncState.members;
+  const profiles = syncState.profiles;
+  const msgs = syncState.msgs;
+  const myUid = syncState.myUid;
 
-  // ====== 追加: Chat ページPV送信（1回だけ） ======
-  const sentChatPV = useRef(false);
-  useEffect(() => {
-    if (!roomId) return;
-    if (sentChatPV.current) return;
-    sentChatPV.current = true;
-    (async () => {
-      try {
-        await ensureAnon();
-        const fns = getFunctions(undefined, 'asia-northeast1');
-        const call = httpsCallable(fns, 'trackVisit');
-        await call({
-          page: 'chat',
-          src: typeof document !== 'undefined' ? document.referrer : '',
-        });
-      } catch {
-        /* noop */
-      }
-    })();
-  }, [roomId]);
-  // ==============================================
-
-  // ルーム購読
-  useEffect(() => {
-    (async () => {
-      if (!roomId) return;
-      await ensureAnon();
-      setMyUid(auth.currentUser?.uid || '');
-
-      const roomUnsub = onSnapshot(doc(db, 'rooms', roomId), (roomSnap) => {
-        if (!roomSnap.exists()) return;
-        const data = roomSnap.data() as any;
-        setMembers(Array.isArray(data.members) ? data.members : []);
-        setProfiles((data.profiles || {}) as Record<string, ProfileSnap>);
-
-        // 片方退室のUI通知
-        const ms: string[] = Array.isArray(data.members) ? data.members : [];
-        if (auth.currentUser?.uid && ms.length === 1 && ms.includes(auth.currentUser.uid)) {
-          setPeerLeftNotice(true);
-        }
-      });
-
-      // メッセージ購読
-      const q = query(
-        collection(db, 'rooms', roomId, 'messages'),
-        orderBy('createdAt', 'asc'),
-        limit(200)
-      );
-      const msgUnsub = onSnapshot(q, (ss) => {
-        const list: ChatMsg[] = ss.docs.map((d) => {
-          const v = d.data() as any;
-          return { id: d.id, text: v.text, uid: v.uid, system: !!v.system, createdAt: v.createdAt };
-        });
-        setMsgs(list);
-        if (list.some(m => m.system && m.text === '会話相手が退席しました')) {
-          setPeerLeftNotice(false);
-        }
-      });
-
-      return () => {
-        roomUnsub();
-        msgUnsub();
-        if (adTimerRef.current) clearInterval(adTimerRef.current);
-      };
-    })();
-  }, [roomId]);
-
-  // === 相手/自分のUIDをより堅牢に特定 ===
   const partnerUid = useMemo(() => {
     const profileKeys = Object.keys(profiles || {});
-    const byProfiles = profileKeys.find(k => k !== myUid && k !== 'ownerAI');
+    const byProfiles = profileKeys.find((k) => k !== myUid && k !== 'ownerAI');
     if (byProfiles) return byProfiles;
-
-    const byMembers = members.find(m => m !== myUid && m !== 'ownerAI');
+    const byMembers = members.find((m) => m !== myUid && m !== 'ownerAI');
     if (byMembers) return byMembers;
-
     return members.includes('ownerAI') ? 'ownerAI' : '';
   }, [profiles, members, myUid]);
 
-  // ローカル保存の復元は初回マウント後
   const [meLocal, setMeLocal] = useState<ProfileSnap>({
     nickname: 'あなた',
     profile: '...',
     icon: DEFAULT_USER_ICON,
   });
-  useEffect(() => {
-    try {
-      setMeLocal({
-        nickname: localStorage.getItem('amayadori_nickname') || 'あなた',
-        profile:  localStorage.getItem('amayadori_profile')  || '...',
-        icon:     localStorage.getItem('amayadori_icon')     || DEFAULT_USER_ICON,
-      });
-    } catch {}
-  }, []);
 
-  // 表示用プロフィール（room.profiles を優先、無ければ meLocal）
   const me: ProfileSnap = {
     nickname: profiles[myUid]?.nickname || meLocal.nickname,
-    profile:  profiles[myUid]?.profile  || meLocal.profile,
-    icon:     profiles[myUid]?.icon     || meLocal.icon,
+    profile: profiles[myUid]?.profile || meLocal.profile,
+    icon: profiles[myUid]?.icon || meLocal.icon,
   };
 
-  const you: ProfileSnap =
-    partnerUid === 'ownerAI'
-      ? { nickname: 'オーナー', profile: '雨宿りカフェのオーナー', icon: OWNER_ICON }
-      : {
-          nickname: profiles[partnerUid]?.nickname || '相手',
-          profile:  profiles[partnerUid]?.profile  || '...',
-          icon:     profiles[partnerUid]?.icon     || DEFAULT_USER_ICON,
-        };
+  const you: ProfileSnap = partnerUid === 'ownerAI'
+    ? { nickname: 'オーナー', profile: '雨宿りカフェのオーナー', icon: OWNER_ICON }
+    : {
+        nickname: profiles[partnerUid]?.nickname || '相手',
+        profile: profiles[partnerUid]?.profile || '...',
+        icon: profiles[partnerUid]?.icon || DEFAULT_USER_ICON,
+      };
 
-  // 話題候補（最初だけ）
-  useEffect(() => {
-    if (!roomId || !myUid || suggestions.length > 0) return;
-    const fn = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'genStarters');
-    fn({ roomId })
-      .then((res: any) => {
-        const s: string[] = Array.isArray(res?.data?.starters) ? res.data.starters : [];
-        if (s.length) setSuggestions(s.slice(0, 3));
-      })
-      .catch(() => {
-        setSuggestions([
-          'この街で雨の日に行きたい場所は？',
-          '最近ハマってる飲み物はありますか？',
-          '静かな雨音って落ち着きますね。'
-        ]);
-      });
-  }, [roomId, myUid, suggestions.length]);
+  function setUiPatch(patch: Partial<ChatUiState>) {
+    setUi((prev) => ({ ...prev, ...patch }));
+  }
+
+  function setSyncPatch(patch: Partial<ChatSyncState>) {
+    setSyncState((prev) => ({ ...prev, ...patch }));
+  }
+
+  function stopAdTimer(reason: string) {
+    if (adTimerRef.current) {
+      clearInterval(adTimerRef.current);
+      adTimerRef.current = null;
+      logChat('timer:cooldown:stop', { reason });
+    }
+  }
 
   function autoResize() {
     const el = taRef.current;
@@ -201,9 +132,10 @@ function ChatPageInner() {
 
   async function send() {
     const text = draft.trim();
-    if (!text || !roomId) return;
+    if (!text || !roomId || phase !== 'matched') return;
     await ensureAnon();
-    const uid = auth.currentUser?.uid!;
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
     await addDoc(collection(db, 'rooms', roomId, 'messages'), {
       text,
       uid,
@@ -216,29 +148,42 @@ function ChatPageInner() {
 
   function startPostLeaveAd() {
     try {
-      const until = Date.now() + POST_LEAVE_AD_SEC * 1000;
-      localStorage.setItem('amayadori_cd_until', String(until));
+      localStorage.setItem('amayadori_cd_until', String(Date.now() + POST_LEAVE_AD_SEC * 1000));
     } catch {}
-    setPostLeaveLeft(POST_LEAVE_AD_SEC);
-    setShowPostLeaveAd(true);
-    if (adTimerRef.current) clearInterval(adTimerRef.current);
+    stopAdTimer('restart');
+    setPhase('cooldown');
+    setUiPatch({ showPostLeaveAd: true, postLeaveLeft: POST_LEAVE_AD_SEC, showLeaveConfirm: false });
+    logChat('cooldown:start', { roomId });
     adTimerRef.current = setInterval(() => {
-      setPostLeaveLeft((v) => {
-        if (v <= 1) {
-          clearInterval(adTimerRef.current);
-          setShowPostLeaveAd(false);
-          r.push('/amayadori');
-          return 0;
+      setUi((prev) => {
+        if (prev.postLeaveLeft <= 1) {
+          stopAdTimer('finished');
+          setTimeout(() => {
+            setUiPatch({ showPostLeaveAd: false, postLeaveLeft: 0 });
+            r.push('/amayadori');
+          }, 0);
+          return { ...prev, postLeaveLeft: 0 };
         }
-        return v - 1;
+        return { ...prev, postLeaveLeft: prev.postLeaveLeft - 1 };
       });
+      return undefined as never;
     }, 1000);
   }
 
+  async function leaveRoomOnServer() {
+    await ensureAnon();
+    await httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'leaveRoom')({ roomId });
+  }
+
   async function leave() {
+    if (syncState.hasStartedLeave) {
+      logChat('leave:skip-duplicate', { roomId });
+      return;
+    }
+    setSyncPatch({ hasStartedLeave: true });
+    setPhase('leaving');
     try {
-      await ensureAnon();
-      await httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'leaveRoom')({ roomId });
+      await leaveRoomOnServer();
     } catch (e) {
       console.error(e);
     }
@@ -247,34 +192,119 @@ function ChatPageInner() {
     startPostLeaveAd();
   }
 
-  const hasSystemPeerLeft = msgs.some(m => m.system && m.text === '会話相手が退席しました');
+  const hasSystemPeerLeft = msgs.some((m) => m.system && m.text === '会話相手が退席しました');
   const isOwnerRoom = members.includes('ownerAI');
 
+  useEffect(() => {
+    const arr: Drop[] = Array.from({ length: 100 }).map((_, i) => ({
+      i,
+      x: Math.random() * 100,
+      delay: Math.random() * 2,
+      duration: 0.5 + Math.random() * 0.5,
+      width: 1 + Math.random() * 2,
+      height: 60 + Math.random() * 40,
+    }));
+    setDrops(arr);
+  }, []);
+
+  useEffect(() => {
+    try {
+      setMeLocal({
+        nickname: localStorage.getItem('amayadori_nickname') || 'あなた',
+        profile: localStorage.getItem('amayadori_profile') || '...',
+        icon: localStorage.getItem('amayadori_icon') || DEFAULT_USER_ICON,
+      });
+    } catch {
+      // noop
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!roomId || sentChatPV.current) return;
+    sentChatPV.current = true;
+    (async () => {
+      try {
+        await ensureAnon();
+        await httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'trackVisit')({
+          page: 'chat',
+          src: typeof document !== 'undefined' ? document.referrer : '',
+        });
+      } catch {
+        // noop
+      }
+    })();
+  }, [roomId]);
+
+  useEffect(() => {
+    if (!roomId) return;
+    let roomUnsub: (() => void) | null = null;
+    let msgUnsub: (() => void) | null = null;
+    void (async () => {
+      await ensureAnon();
+      setSyncPatch({ myUid: auth.currentUser?.uid || '' });
+      setPhase('matched');
+
+      roomUnsub = onSnapshot(doc(db, 'rooms', roomId), (roomSnap) => {
+        if (!roomSnap.exists()) return;
+        const data = roomSnap.data() as any;
+        const nextMembers = Array.isArray(data.members) ? data.members : [];
+        setSyncPatch({
+          members: nextMembers,
+          profiles: (data.profiles || {}) as Record<string, ProfileSnap>,
+        });
+        if (auth.currentUser?.uid && nextMembers.length === 1 && nextMembers.includes(auth.currentUser.uid)) {
+          setUiPatch({ peerLeftNotice: true });
+        }
+      });
+
+      const q = query(collection(db, 'rooms', roomId, 'messages'), orderBy('createdAt', 'asc'), limit(200));
+      msgUnsub = onSnapshot(q, (ss) => {
+        const list: ChatMsg[] = ss.docs.map((d) => {
+          const v = d.data() as any;
+          return { id: d.id, text: v.text, uid: v.uid, system: !!v.system, createdAt: v.createdAt };
+        });
+        setSyncPatch({ msgs: list });
+        if (list.some((m) => m.system && m.text === '会話相手が退席しました')) {
+          setUiPatch({ peerLeftNotice: false });
+        }
+      });
+    })();
+
+    return () => {
+      roomUnsub?.();
+      msgUnsub?.();
+      stopAdTimer('unmount');
+    };
+  }, [roomId]);
+
+  useEffect(() => {
+    if (!roomId || !myUid || suggestions.length > 0) return;
+    const fn = httpsCallable(getFunctions(undefined, 'asia-northeast1'), 'genStarters');
+    fn({ roomId })
+      .then((res: any) => {
+        const s: string[] = Array.isArray(res?.data?.starters) ? res.data.starters : [];
+        if (s.length) setSuggestions(s.slice(0, 3));
+      })
+      .catch(() => {
+        setSuggestions([
+          'この街で雨の日に行きたい場所は？',
+          '最近ハマってる飲み物はありますか？',
+          '静かな雨音って落ち着きますね。',
+        ]);
+      });
+  }, [roomId, myUid, suggestions.length]);
+
   return (
-    // ★ ここだけ変更：テーマクラスを付与
     <div className="theme-amayadori w-full h-full overflow-hidden">
-      {/* 雨（SSR差分を許容） */}
       <div id="rain-container" suppressHydrationWarning>
         {drops.map((d) => (
-          <div
-            key={d.i}
-            className="rain-drop"
-            style={{
-              left: `${d.x}%`,
-              animationDelay: `${d.delay}s`,
-              animationDuration: `${d.duration}s`,
-              width: `${d.width}px`,
-              height: `${d.height}px`,
-            }}
-          />
+          <div key={d.i} className="rain-drop" style={{ left: `${d.x}%`, animationDelay: `${d.delay}s`, animationDuration: `${d.duration}s`, width: `${d.width}px`, height: `${d.height}px` }} />
         ))}
       </div>
 
       <div id="app-container" className="relative z-10 w-full h-full flex items-center justify-center p-4">
         <div id="chat-screen" className="w-full h-full flex flex-col glass-card">
-          {/* ヘッダ：相手/自分のプロフィール（room.profiles 優先、ローカル復元込み） */}
           <header className="w-full p-4 border-b border-gray-700/50 flex items-center justify-between flex-shrink-0">
-            {/* 相手 */}
             <div className="flex items-center space-x-3">
               <img className="w-10 h-10 rounded-full object-cover" src={you.icon || DEFAULT_USER_ICON} alt="" />
               <div>
@@ -282,147 +312,80 @@ function ChatPageInner() {
                 <p className="text-xs text-gray-400" suppressHydrationWarning>{you.profile || '...'}</p>
               </div>
             </div>
-
-            {/* タイトル */}
             <div className="text-center">
               <h2 className="text-lg font-bold">Cafe Amayadori</h2>
               <p className="text-xs text-gray-400">{isOwnerRoom ? 'オーナーとあなた' : '相手とあなた'}</p>
             </div>
-
-            {/* 自分 + 退室ボタン */}
             <div className="flex items-center space-x-3">
               <div className="text-right">
                 <p className="font-bold" suppressHydrationWarning>{me.nickname || 'あなた'}</p>
                 <p className="text-xs text-gray-400" suppressHydrationWarning>{me.profile || '...'}</p>
               </div>
               <img className="w-10 h-10 rounded-full object-cover" src={me.icon || DEFAULT_USER_ICON} alt="" />
-              <button className="btn-exit ml-2" onClick={() => setShowLeaveConfirm(true)}>退室</button>
+              <button className="btn-exit ml-2" onClick={() => setUiPatch({ showLeaveConfirm: true })} disabled={phase === 'leaving' || phase === 'cooldown'}>退室</button>
             </div>
           </header>
 
-          {/* メッセージ */}
           <main id="chat-messages" className="flex-1 p-4 overflow-y-auto flex flex-col space-y-4">
-            {(hasSystemPeerLeft || peerLeftNotice) && (
-              <div className="text-center text-gray-400 text-sm italic my-2">会話相手が退席しました</div>
-            )}
-
+            {(hasSystemPeerLeft || ui.peerLeftNotice) && <div className="text-center text-gray-400 text-sm italic my-2">会話相手が退席しました</div>}
             {msgs.map((m) => {
               if (m.system) {
                 if (m.text === '会話相手が退席しました') return null;
                 return <div key={m.id} className="text-center text-gray-400 text-sm italic my-2">{m.text}</div>;
               }
-              const mine = (auth.currentUser?.uid && m.uid === auth.currentUser?.uid) || false;
+              const mine = Boolean(auth.currentUser?.uid && m.uid === auth.currentUser.uid);
               const partnerIcon = you.icon || (partnerUid === 'ownerAI' ? OWNER_ICON : DEFAULT_USER_ICON);
               return (
                 <div key={m.id} className={`flex items-end gap-2 ${mine ? 'justify-end' : 'justify-start'}`}>
-                  {!mine && (
-                    <img className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                      src={partnerIcon}
-                      alt=""
-                      onError={(e) => ((e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON)}
-                    />
-                  )}
+                  {!mine && <img className="w-8 h-8 rounded-full object-cover flex-shrink-0" src={partnerIcon} alt="" onError={(e) => ((e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON)} />}
                   <div className={`chat-bubble ${mine ? 'me' : 'other'}`}>
                     {!mine && <span className="block text-xs font-bold mb-1 text-purple-300">{you.nickname || (partnerUid === 'ownerAI' ? 'オーナー' : '相手')}</span>}
                     <p>{m.text}</p>
                   </div>
-                  {mine && (
-                    <img className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                      src={me.icon || DEFAULT_USER_ICON}
-                      alt=""
-                      onError={(e) => ((e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON)}
-                    />
-                  )}
+                  {mine && <img className="w-8 h-8 rounded-full object-cover flex-shrink-0" src={me.icon || DEFAULT_USER_ICON} alt="" onError={(e) => ((e.currentTarget as HTMLImageElement).src = DEFAULT_USER_ICON)} />}
                 </div>
               );
             })}
           </main>
 
-          {/* フッター（話題候補） */}
           <footer className="p-4 flex-shrink-0">
             {showSuggestions && suggestions.length > 0 && (
               <div id="suggestion-area" className="flex-wrap justify-center gap-2 mb-3 flex">
                 {suggestions.slice(0, 3).map((t) => (
-                  <button
-                    key={t}
-                    className="suggestion-btn"
-                    onClick={() => {
-                      setDraft(t);
-                      setShowSuggestions(false);
-                      setTimeout(() => taRef.current?.focus(), 0);
-                    }}
-                  >
-                    {t}
-                  </button>
+                  <button key={t} className="suggestion-btn" onClick={() => { setDraft(t); setShowSuggestions(false); setTimeout(() => taRef.current?.focus(), 0); }}>{t}</button>
                 ))}
               </div>
             )}
             <div className="flex items-center space-x-3">
-              <textarea
-                ref={taRef}
-                className="flex-1 px-4 py-3 message-textarea"
-                placeholder="メッセージを送信..."
-                rows={1}
-                value={draft}
-                onChange={(e) => {
-                  setDraft(e.target.value);
-                  autoResize();
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    send();
-                  }
-                }}
-              />
-              <button
-                className="w-12 h-12 rounded-full text-white flex items-center justify-center btn-gradient flex-shrink-0"
-                onClick={send}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="22" y1="2" x2="11" y2="13"></line>
-                  <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-                </svg>
+              <textarea ref={taRef} className="flex-1 px-4 py-3 message-textarea" placeholder="メッセージを送信..." rows={1} value={draft} onChange={(e) => { setDraft(e.target.value); autoResize(); }} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void send(); } }} />
+              <button className="w-12 h-12 rounded-full text-white flex items-center justify-center btn-gradient flex-shrink-0" onClick={() => void send()} disabled={phase !== 'matched'}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
               </button>
             </div>
           </footer>
         </div>
       </div>
 
-      {/* 扉 */}
-      <div
-        id="door-animation"
-        className={`fixed inset-0 z-50 flex pointer-events-none ${doorOpen ? 'open' : ''} ${doorOpen ? '' : 'hidden'}`}
-      >
-        <div className="door left"></div>
-        <div className="door right"></div>
-      </div>
+      <div id="door-animation" className={`fixed inset-0 z-50 flex pointer-events-none ${doorOpen ? 'open' : ''} ${doorOpen ? '' : 'hidden'}`}><div className="door left"></div><div className="door right"></div></div>
 
-      {/* 退室確認モーダル */}
-      {showLeaveConfirm && (
+      {ui.showLeaveConfirm && (
         <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center">
           <div className="glass-card p-6 w-full max-w-sm text-center space-y-4">
             <p className="text-lg font-semibold">本当に退席しますか？</p>
             <div className="flex gap-3 justify-center">
-              <button className="btn-secondary" onClick={() => setShowLeaveConfirm(false)}>いいえ</button>
-              <button className="btn-gradient" onClick={async () => { setShowLeaveConfirm(false); await leave(); }}>
-                はい
-              </button>
+              <button className="btn-secondary" onClick={() => setUiPatch({ showLeaveConfirm: false })}>いいえ</button>
+              <button className="btn-gradient" onClick={() => { setUiPatch({ showLeaveConfirm: false }); void leave(); }} disabled={phase === 'leaving' || phase === 'cooldown'}>はい</button>
             </div>
           </div>
         </div>
       )}
 
-      {/* 退室後広告 */}
-      {showPostLeaveAd && (
-        <div className="fixed inset-0 z-[60] bg-black/80 flex items中心 justify-center">
+      {ui.showPostLeaveAd && (
+        <div className="fixed inset-0 z-[60] bg-black/80 flex items-center justify-center">
           <div className="glass-card p-6 w-full max-w-md text-center space-y-4">
             <p className="text-sm text-gray-400">広告</p>
-            <div className="w-full h-96 bg-gray-700/80 rounded-xl flex items-center justify-center">
-              <p className="px-6">ここにインタースティシャル広告（SDK/タグ）を差し込み</p>
-            </div>
-            <p className="text-gray-300">閉じるまで {postLeaveLeft} 秒</p>
+            <div className="w-full h-96 bg-gray-700/80 rounded-xl flex items-center justify-center"><p className="px-6">ここにインタースティシャル広告（SDK/タグ）を差し込み</p></div>
+            <p className="text-gray-300">閉じるまで {ui.postLeaveLeft} 秒</p>
           </div>
         </div>
       )}
@@ -431,9 +394,5 @@ function ChatPageInner() {
 }
 
 export default function ChatPage() {
-  return (
-    <Suspense fallback={<div />}>
-      <ChatPageInner />
-    </Suspense>
-  );
+  return <Suspense fallback={<div />}><ChatPageInner /></Suspense>;
 }


### PR DESCRIPTION
### Motivation
- 従来の暗黙的な `useState` 群による待機/入退室処理を明示的な有限状態（`profile -> region -> joining -> waiting -> matched -> chat -> leaving -> cooldown`）へ整理して挙動を安定化させるため。 
- タイマー・購読・トークン等のランタイムリソースを状態遷移に紐づけて適切に止める／解除することで、`matched` 後の stale 表示抑止・オーナー遷移中の待機エラー抑止・二重キャンセル防止を実現するため。 

### Description
- `app/amayadori/page.tsx` に `FlowState` / `UiState` / `SyncState` を導入し、画面フローと表示用 state とサーバ同期用 state を分離しました。 
- ジョイン／監視／キャンセル／クールダウン／オーナー遷移の責務を `beginJoinFlow` / `enterQueue` / `startHeartbeat` / `handleEntrySnapshot` / `cancelCurrentEntry` / `beginCooldown` / `startOwnerRoomTransition` / `sendBeaconCancel` 等に分割し、1関数1責務へ整理しました。 
- タイマー・リスナー用の共通ヘルパー（`stopOwnerPromptTimer` / `stopHeartbeat` / `stopCooldownTimer` / `stopRewardedTimer` / `detachEntryListener` / `clearQueueRuntime`）と診断用ログ `logFlow`、イベント別のクリーンアップ行列 `EVENT_CLEANUP_MATRIX` を追加しました。 
- `app/chat/page.tsx` でも `ChatPhase` を導入して `matched -> leaving -> cooldown` を明示化し、`leaveRoomOnServer` と `startPostLeaveAd` に責務を分割して `hasStartedLeave` による二重退室ガードを追加しました。 
- UI の文言やボタンの挙動をフローに合わせて切り替えるようにし、待機中の owner prompt、再試行、エラーメッセージ表示、退室後広告の再開ロジック等を状態遷移に従属させました. 

### Testing
- `npm run lint` を実行し成功しましたが既存の `@next/next/no-img-element` 警告は残っています（警告のみ）。
- `npx tsc --noEmit` を実行して型チェックは問題ありませんでした。 
- `npm run build` を実行しましたが、この実行環境で Next.js が Google Fonts (`Inter`, `Noto Serif JP`) を取得できずビルド失敗となったため、ビルドは環境依存の外部フェッチエラーで失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3eb777c48333a094039b281c436f)