### PR TITLE
Guard Firebase init during prerender

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -38,6 +38,11 @@ export default function AdminLogin() {
 
   // 認証状態を監視。匿名でなければ /admin へ。
   useEffect(() => {
+    if (!auth) {
+      setErr('Firebase 設定が不足しているためログインできません。');
+      return;
+    }
+
     const unsub = onAuthStateChanged(auth, (u) => {
       setUid(u?.uid ?? null);
       setIsAnon(!!u?.isAnonymous);
@@ -48,6 +53,7 @@ export default function AdminLogin() {
 
   // 匿名セッションは破棄。永続化は Local 固定。
   useEffect(() => {
+    if (!auth) return;
     if (auth.currentUser?.isAnonymous) signOut(auth).catch(() => {});
     setPersistence(auth, browserLocalPersistence).catch(() => {});
   }, []);
@@ -57,6 +63,7 @@ export default function AdminLogin() {
     setErr(null);
     setBusy(true);
     try {
+      if (!auth) throw new Error('Firebase 設定が不足しています。');
       if (auth.currentUser?.isAnonymous) {
         try {
           const cred = EmailAuthProvider.credential(email.trim(), pw);
@@ -83,7 +90,7 @@ export default function AdminLogin() {
   }
 
   async function doSignOut() {
-    try { await signOut(auth); } catch {}
+    try { if (auth) await signOut(auth); } catch {}
   }
 
   return (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -77,6 +77,13 @@ export default function AdminPage() {
 
   // 認証/権限ガード：非ログイン or 匿名 → /admin/login、ログイン済は checkAdmin へ
   useEffect(() => {
+    if (!auth) {
+      setErr('Firebase 設定が不足しているため管理画面を表示できません。');
+      setAdmin(false);
+      setReady(true);
+      return;
+    }
+
     const unsub = onAuthStateChanged(auth, async (u) => {
       setErr(null);
       try {
@@ -106,6 +113,8 @@ export default function AdminPage() {
     try {
       /* ---------- 日次（直近30日） ----------
          まず「元のクエリ」を試し、失敗したらフォールバックで全件→idソート */
+      if (!db) throw new Error('Firebase Firestore is not configured');
+
       let rowsDesc: DailyRow[] = [];
       try {
         const qDaily = query(collection(db, 'metrics_daily'), orderBy(documentId(), 'desc'), limit(30));

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -134,8 +134,9 @@ function ChatPageInner() {
     const text = draft.trim();
     if (!text || !roomId || phase !== 'matched') return;
     await ensureAnon();
-    const uid = auth.currentUser?.uid;
+    const uid = auth?.currentUser?.uid;
     if (!uid) return;
+    if (!db) return;
     await addDoc(collection(db, 'rooms', roomId, 'messages'), {
       text,
       uid,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,8 +3,20 @@ import { getFunctions, httpsCallable } from 'firebase/functions'
 import { app } from './firebase'
 
 const region = process.env.NEXT_PUBLIC_FUNCTIONS_REGION || 'asia-northeast1'
-const fns = getFunctions(app, region)
+const fns = app ? getFunctions(app, region) : null
 
-export const callEnter   = httpsCallable(fns, 'enter')
-export const callLeave   = httpsCallable(fns, 'leaveRoom')
-export const callOwnerAI = httpsCallable(fns, 'ownerAI')
+function missingFirebaseError() {
+  throw new Error('Firebase is not configured')
+}
+
+export const callEnter = fns
+  ? httpsCallable(fns, 'enter')
+  : async () => missingFirebaseError()
+
+export const callLeave = fns
+  ? httpsCallable(fns, 'leaveRoom')
+  : async () => missingFirebaseError()
+
+export const callOwnerAI = fns
+  ? httpsCallable(fns, 'ownerAI')
+  : async () => missingFirebaseError()

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,31 +1,47 @@
 // lib/firebase.ts
-import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getAuth, signInAnonymously, User } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
+import { FirebaseApp, getApp, getApps, initializeApp } from 'firebase/app';
+import { Auth, getAuth, signInAnonymously, User } from 'firebase/auth';
+import { Firestore, getFirestore } from 'firebase/firestore';
+import { FirebaseStorage, getStorage } from 'firebase/storage';
 
 // App Check（必要なときだけ使う）
-import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
+import { ReCaptchaV3Provider, initializeAppCheck } from 'firebase/app-check';
 
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-export const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+export const isFirebaseConfigured = Object.values(firebaseConfig).every(
+  (value) => typeof value === 'string' && value.trim().length > 0
+);
+
+function warnMissingFirebaseConfig() {
+  if (typeof window === 'undefined') {
+    console.warn('[firebase] Firebase config is missing. Skipping client SDK initialization during prerender/build.');
+  }
+}
+
+export const app: FirebaseApp | null = isFirebaseConfigured
+  ? (getApps().length ? getApp() : initializeApp(firebaseConfig))
+  : null;
+
+if (!isFirebaseConfigured) {
+  warnMissingFirebaseConfig();
+}
 
 // -------------------------
 // App Check（フラグで可/不可）
 // -------------------------
 // .env.local で NEXT_PUBLIC_ENABLE_APPCHECK=1 のときだけ有効化
 const shouldEnableAppCheck =
-  typeof window !== 'undefined' && process.env.NEXT_PUBLIC_ENABLE_APPCHECK === '1';
+  typeof window !== 'undefined' && process.env.NEXT_PUBLIC_ENABLE_APPCHECK === '1' && !!app;
 
-if (shouldEnableAppCheck) {
+if (shouldEnableAppCheck && app) {
   try {
     // デバッグ時は自動でトークンを発行（App Check コンソールに登録して使用）
     (self as any).FIREBASE_APPCHECK_DEBUG_TOKEN ??= true;
@@ -41,12 +57,16 @@ if (shouldEnableAppCheck) {
   }
 }
 
-export const auth = getAuth(app);
-export const db = getFirestore(app);
-export const storage = getStorage(app);
+export const auth: Auth | null = app ? getAuth(app) : null;
+export const db: Firestore | null = app ? getFirestore(app) : null;
+export const storage: FirebaseStorage | null = app ? getStorage(app) : null;
 
 // 未ログインなら匿名ログイン
 export async function ensureAnon(): Promise<User> {
+  if (!auth) {
+    throw new Error('Firebase is not configured');
+  }
+
   if (!auth.currentUser) {
     await signInAnonymously(auth);
   }


### PR DESCRIPTION
### Motivation
- Prevent Next.js prerender/build from initializing the Firebase web SDK when public `NEXT_PUBLIC_FIREBASE_*` env vars are missing, which caused `FirebaseError: Error (auth/invalid-api-key)` during prerender. 
- Make Firebase-dependent call sites fail gracefully in environments (build/prerender) where client-side Firebase config is intentionally absent.

### Description
- Add `isFirebaseConfigured` and conditional initialization in `lib/firebase.ts` so `initializeApp()`, `getAuth()` and `getFirestore()` are only called when all required `NEXT_PUBLIC_FIREBASE_*` values are present, and export nullable `app`, `auth`, and `db` handles. 
- Guard App Check initialization behind the same condition and surface a clear runtime error from `ensureAnon()` when Firebase is not configured. 
- Change `lib/api.ts` to avoid calling `getFunctions()` when `app` is null and make `callEnter`/`callLeave`/`callOwnerAI` return a clear error when Firebase is missing. 
- Add null-safety and early-return/error paths in client pages so they don't run Firebase auth/firestore APIs during prerender: `app/admin/login/page.tsx` now checks `auth` before starting watchers and auth operations, `app/admin/page.tsx` checks `auth`/`db` before running admin flows, and `app/chat/page.tsx` checks `auth`/`db` before writing messages. 

### Testing
- Ran `npm run build`, which no longer fails with the earlier `auth/invalid-api-key` prerender error but instead stops later due to external Google Fonts fetch failures in this environment (network-related), confirming the Firebase init issue was addressed. 
- Ran `timeout 30s npx tsc --noEmit`, which timed out in this environment (`EXIT:124`) and did not complete within the time limit. 
- Performed a code review of the diffs to verify the added guards and null-safety checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9bdc2c488333a4edf3572f8bf90f)